### PR TITLE
add InstalledPath type

### DIFF
--- a/cmd/snappy/cmd_install.go
+++ b/cmd/snappy/cmd_install.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snappy"
 )
@@ -66,12 +67,12 @@ func (x *cmdInstall) doInstall() error {
 		return errors.New(i18n.G("package name is required"))
 	}
 
-	flags := snappy.DoInstallGC
+	flags := pkg.DoInstallGC
 	if x.DisableGC {
 		flags = 0
 	}
 	if x.AllowUnauthenticated {
-		flags |= snappy.AllowUnauthenticated
+		flags |= pkg.AllowUnauthenticated
 	}
 	// TRANSLATORS: the %s is a pkgname
 	fmt.Printf(i18n.G("Installing %s\n"), pkgName)

--- a/cmd/snappy/cmd_list.go
+++ b/cmd/snappy/cmd_list.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/part/abstract"
 	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/snappy"
 )
@@ -90,7 +91,7 @@ func formatDate(t time.Time) string {
 	return fmt.Sprintf("%v-%02d-%02d", t.Year(), int(t.Month()), t.Day())
 }
 
-func showInstalledList(installed []snappy.Part, o io.Writer) {
+func showInstalledList(installed []abstract.Part, o io.Writer) {
 	w := tabwriter.NewWriter(o, 5, 3, 1, ' ', 0)
 
 	fmt.Fprintln(w, "Name\tDate\tVersion\tDeveloper\t")
@@ -104,7 +105,7 @@ func showInstalledList(installed []snappy.Part, o io.Writer) {
 	showRebootMessage(installed, o)
 }
 
-func showVerboseList(installed []snappy.Part, o io.Writer) {
+func showVerboseList(installed []abstract.Part, o io.Writer) {
 	w := tabwriter.NewWriter(o, 5, 3, 1, ' ', 0)
 
 	fmt.Fprintln(w, i18n.G("Name\tDate\tVersion\tDeveloper\t"))
@@ -126,7 +127,7 @@ func showVerboseList(installed []snappy.Part, o io.Writer) {
 	showRebootMessage(installed, o)
 }
 
-func showRebootMessage(installed []snappy.Part, o io.Writer) {
+func showRebootMessage(installed []abstract.Part, o io.Writer) {
 	// Initialise to handle systems without a provisioned "other"
 	otherVersion := "0"
 	currentVersion := "0"
@@ -167,7 +168,7 @@ func showRebootMessage(installed []snappy.Part, o io.Writer) {
 	}
 }
 
-func showUpdatesList(installed []snappy.Part, updates []snappy.Part, o io.Writer) {
+func showUpdatesList(installed []abstract.Part, updates []abstract.Part, o io.Writer) {
 	// TODO tabwriter and output in general to adapt to the spec
 	w := tabwriter.NewWriter(o, 5, 3, 1, ' ', 0)
 	defer w.Flush()

--- a/cmd/snappy/cmd_update.go
+++ b/cmd/snappy/cmd_update.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/part/abstract"
+	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snappy"
 )
@@ -66,13 +68,13 @@ func (x *cmdUpdate) Execute(args []string) (err error) {
 
 func (x *cmdUpdate) doUpdate() error {
 	// FIXME: handle (more?) args
-	flags := snappy.DoInstallGC
+	flags := pkg.DoInstallGC
 	if x.DisableGC {
 		flags = 0
 	}
 
 	var err error
-	var updates []snappy.Part
+	var updates []abstract.Part
 	if x.Positional.PackageName != "" {
 		updates, err = snappy.Update(x.Positional.PackageName, flags, progress.MakeProgressBar())
 	} else {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -36,6 +36,8 @@ import (
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/lockfile"
 	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/part/abstract"
+	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/pkg/lightweight"
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/release"
@@ -143,9 +145,9 @@ func v1Get(c *Command, r *http.Request) Response {
 }
 
 type metarepo interface {
-	Details(string, string) ([]snappy.Part, error)
-	All() ([]snappy.Part, error)
-	Updates() ([]snappy.Part, error)
+	Details(string, string) ([]abstract.Part, error)
+	All() ([]abstract.Part, error)
+	Updates() ([]abstract.Part, error)
 }
 
 var newRemoteRepo = func() metarepo {
@@ -170,7 +172,7 @@ func getPackageInfo(c *Command, r *http.Request) Response {
 	defer lock.Unlock()
 
 	repo := newRemoteRepo()
-	var part snappy.Part
+	var part abstract.Part
 	if parts, _ := repo.Details(name, origin); len(parts) > 0 {
 		part = parts[0]
 	}
@@ -226,7 +228,7 @@ func webify(result map[string]string, resource string) map[string]string {
 	return result
 }
 
-type byQN []snappy.Part
+type byQN []abstract.Part
 
 func (ps byQN) Len() int      { return len(ps) }
 func (ps byQN) Swap(a, b int) { ps[a], ps[b] = ps[b], ps[a] }
@@ -593,7 +595,7 @@ type packageInstruction struct {
 }
 
 func (inst *packageInstruction) install() interface{} {
-	flags := snappy.DoInstallGC
+	flags := pkg.DoInstallGC
 	if inst.LeaveOld {
 		flags = 0
 	}
@@ -609,7 +611,7 @@ func (inst *packageInstruction) install() interface{} {
 }
 
 func (inst *packageInstruction) update() interface{} {
-	flags := snappy.DoInstallGC
+	flags := pkg.DoInstallGC
 	if inst.LeaveOld {
 		flags = 0
 	}
@@ -705,7 +707,7 @@ func postPackage(c *Command, r *http.Request) Response {
 
 const maxReadBuflen = 1024 * 1024
 
-func newSnapImpl(filename string, origin string, unsignedOk bool) (snappy.Part, error) {
+func newSnapImpl(filename string, origin string, unsignedOk bool) (abstract.Part, error) {
 	return snappy.NewSnapPartFromSnapFile(filename, origin, unsignedOk)
 }
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -45,25 +45,26 @@ import (
 	"github.com/ubuntu-core/snappy/release"
 	"github.com/ubuntu-core/snappy/snappy"
 	"github.com/ubuntu-core/snappy/systemd"
+	"github.com/ubuntu-core/snappy/part/abstract"
 )
 
 type apiSuite struct {
-	parts []snappy.Part
+	parts []abstract.Part
 	err   error
 	vars  map[string]string
 }
 
 var _ = check.Suite(&apiSuite{})
 
-func (s *apiSuite) Details(string, string) ([]snappy.Part, error) {
+func (s *apiSuite) Details(string, string) ([]abstract.Part, error) {
 	return s.parts, s.err
 }
 
-func (s *apiSuite) All() ([]snappy.Part, error) {
+func (s *apiSuite) All() ([]abstract.Part, error) {
 	return s.parts, s.err
 }
 
-func (s *apiSuite) Updates() ([]snappy.Part, error) {
+func (s *apiSuite) Updates() ([]abstract.Part, error) {
 	return s.parts, s.err
 }
 
@@ -136,7 +137,7 @@ func (s *apiSuite) TestPackageInfoOneIntegration(c *check.C) {
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}
 
 	// the store tells us about v2
-	s.parts = []snappy.Part{&tP{
+	s.parts = []abstract.Part{&tP{
 		name:         "foo",
 		version:      "v2",
 		description:  "description",
@@ -218,7 +219,7 @@ func (s *apiSuite) TestPackageInfoWeirdRoute(c *check.C) {
 	// use the wrong command to force the issue
 	wrongCmd := &Command{Path: "/{what}", d: d}
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}
-	s.parts = []snappy.Part{&tP{name: "foo"}}
+	s.parts = []abstract.Part{&tP{name: "foo"}}
 	c.Check(getPackageInfo(wrongCmd, nil).Self(nil, nil).(*resp).Status, check.Equals, http.StatusInternalServerError)
 }
 
@@ -232,7 +233,7 @@ func (s *apiSuite) TestPackageInfoBadRoute(c *check.C) {
 	c.Assert(route.Name("foo").GetError(), check.NotNil)
 
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}
-	s.parts = []snappy.Part{&tP{name: "foo"}}
+	s.parts = []abstract.Part{&tP{name: "foo"}}
 
 	rsp := getPackageInfo(packageCmd, nil).Self(nil, nil).(*resp)
 
@@ -596,7 +597,7 @@ type cfgc struct {
 
 func (cfgc) IsInstalled(string) bool { return true }
 func (c cfgc) ActiveIndex() int      { return c.idx }
-func (c cfgc) Load(string) (snappy.Part, error) {
+func (c cfgc) Load(string) (abstract.Part, error) {
 	return &tP{name: "foo", version: "v1", origin: "bar", isActive: true, config: c.cfg, configErr: c.err}, nil
 }
 
@@ -890,7 +891,7 @@ func (s *apiSuite) sideloadCheck(c *check.C, content string, unsignedExpected bo
 
 	// setup done
 
-	newSnap = func(fn string, origin string, unauthOk bool) (snappy.Part, error) {
+	newSnap = func(fn string, origin string, unauthOk bool) (abstract.Part, error) {
 		c.Check(origin, check.Equals, snappy.SideloadedOrigin)
 		c.Check(unauthOk, check.Equals, unsignedExpected)
 

--- a/daemon/snappy_part_iface_test.go
+++ b/daemon/snappy_part_iface_test.go
@@ -73,7 +73,7 @@ func (p *tP) Type() pkg.Type       { return p._type }
 func (p *tP) InstalledSize() int64 { return p.installedSize }
 func (p *tP) DownloadSize() int64  { return p.downloadSize }
 
-func (p *tP) Install(progress.Meter, snappy.InstallFlags) (string, error) {
+func (p *tP) Install(progress.Meter, pkg.InstallFlags) (string, error) {
 	return p.installName, p.installErr
 }
 func (p *tP) Uninstall(pb progress.Meter) error { return p.uninstallErr }

--- a/part/abstract/abstract.go
+++ b/part/abstract/abstract.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package abstract
+
+import (
+	"time"
+
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/progress"
+)
+
+// Part representation of a snappy part
+type Part interface {
+
+	// query
+	Name() string
+	Version() string
+	Description() string
+	Origin() string
+	Vendor() string
+
+	Hash() string
+	IsActive() bool
+	IsInstalled() bool
+	// Will become active on the next reboot
+	NeedsReboot() bool
+
+	// returns the date when the snap was last updated
+	Date() time.Time
+
+	// returns the channel of the part
+	Channel() string
+
+	// returns the path to the icon (local or uri)
+	Icon() string
+
+	// Returns app, framework, core
+	Type() pkg.Type
+
+	InstalledSize() int64
+	DownloadSize() int64
+
+	// Install the snap
+	Install(pb progress.Meter, flags pkg.InstallFlags) (name string, err error)
+	// Uninstall the snap
+	Uninstall(pb progress.Meter) error
+	// Config takes a yaml configuration and returns the full snap
+	// config with the changes. Note that "configuration" may be empty.
+	Config(configuration []byte) (newConfig string, err error)
+	// make an inactive part active, or viceversa
+	SetActive(bool, progress.Meter) error
+
+	// get the list of frameworks needed by the part
+	Frameworks() ([]string, error)
+}

--- a/part/local/local.go
+++ b/part/local/local.go
@@ -39,7 +39,7 @@ Gustavo Niemeyer
 @mvogt For example, rather than returning the path to the metadata yaml file, why don't we offer a structure out with those details already parsed?
 */
 
-package installed
+package local
 
 import (
 	"os"
@@ -49,18 +49,18 @@ import (
 	"github.com/ubuntu-core/snappy/helpers"
 )
 
-// InstalledPath represents a installed snap path
-type Path string
+// Part represents a installed snap package
+type Part string
 
-func (i Path) HasConfig() bool {
+func (i Part) HasConfig() bool {
 	return helpers.FileExists(i.ConfigScript())
 }
 
-func (i Path) ConfigScript() string {
+func (i Part) ConfigScript() string {
 	return filepath.Join(string(i), "meta", "hooks", "config")
 }
 
-func (i Path) Origin() string {
+func (i Part) Origin() string {
 	ext := filepath.Ext(filepath.Dir(filepath.Clean(string(i))))
 	if len(ext) < 2 {
 		return ""
@@ -69,23 +69,23 @@ func (i Path) Origin() string {
 	return ext[1:]
 }
 
-func (i Path) YamlPath() string {
+func (i Part) YamlPath() string {
 	return filepath.Join(string(i), "meta", "package.yaml")
 }
 
-func (i Path) ReadmePath() string {
+func (i Part) ReadmePath() string {
 	return filepath.Join(string(i), "meta", "readme.md")
 }
 
-func (i Path) HashesPath() string {
+func (i Part) HashesPath() string {
 	return filepath.Join(string(i), "meta", "hashes.yaml")
 }
 
-func (i Path) Version() string {
+func (i Part) Version() string {
 	return filepath.Base(string(i))
 }
 
-func (i Path) Size() int64 {
+func (i Part) Size() int64 {
 	// FIXME: cache this at install time maybe?
 	totalSize := int64(0)
 	f := func(_ string, info os.FileInfo, err error) error {
@@ -96,7 +96,7 @@ func (i Path) Size() int64 {
 	return totalSize
 }
 
-func (i Path) Date() time.Time {
+func (i Part) Date() time.Time {
 	st, err := os.Stat(string(i))
 	if err != nil {
 		return time.Time{}
@@ -105,11 +105,11 @@ func (i Path) Date() time.Time {
 	return st.ModTime()
 }
 
-func (i Path) RemoveAll() error {
+func (i Part) RemoveAll() error {
 	return os.RemoveAll(string(i))
 }
 
-func (i Path) IsActive() (bool, error) {
+func (i Part) IsActive() (bool, error) {
 	allVersionsDir := filepath.Dir(string(i))
 	p, err := filepath.EvalSymlinks(filepath.Join(allVersionsDir, "current"))
 	if err != nil && !os.IsNotExist(err) {
@@ -118,3 +118,4 @@ func (i Path) IsActive() (bool, error) {
 
 	return p == string(i), nil
 }
+

--- a/part/local/local_test.go
+++ b/part/local/local_test.go
@@ -17,22 +17,25 @@
  *
  */
 
-package snappy
+package local
 
 import (
-	"github.com/ubuntu-core/snappy/part/abstract"
+	"testing"
+
+	. "gopkg.in/check.v1"
 )
 
-// ListInstalled returns all installed snaps
-func ListInstalled() ([]abstract.Part, error) {
-	m := NewMetaRepository()
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
 
-	return m.Installed()
+type LocalPartTestSuite struct {
 }
 
-// ListUpdates returns all snaps with updates
-func ListUpdates() ([]abstract.Part, error) {
-	m := NewMetaRepository()
+var _ = Suite(&LocalPartTestSuite{})
 
-	return m.Updates()
+
+func (s *LocalPartTestSuite) TestLocalPartReadmePath(c *C) {
+	localSnap := Part(c.MkDir())
+
+	c.Assert(localSnap.YamlPath(), Matches, ".*/meta/package.yaml")
 }

--- a/pkg/lightweight/lightweight.go
+++ b/pkg/lightweight/lightweight.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/part/abstract"
 	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/pkg/removed"
 	"github.com/ubuntu-core/snappy/snappy"
@@ -119,7 +120,7 @@ func AllPartBags() map[string]*PartBag {
 }
 
 type repo interface {
-	All() ([]snappy.Part, error)
+	All() ([]abstract.Part, error)
 }
 
 func newCoreRepoImpl() repo {
@@ -221,7 +222,7 @@ type PartBag struct {
 type Concreter interface {
 	IsInstalled(string) bool
 	ActiveIndex() int
-	Load(string) (snappy.Part, error)
+	Load(string) (abstract.Part, error)
 }
 
 // NewConcrete is meant to be overridden in tests; is called when
@@ -264,7 +265,7 @@ type concreteCore struct{}
 
 func (*concreteCore) IsInstalled(string) bool { return true }
 func (*concreteCore) ActiveIndex() int        { return 0 }
-func (*concreteCore) Load(version string) (snappy.Part, error) {
+func (*concreteCore) Load(version string) (abstract.Part, error) {
 	parts, err := newCoreRepo().All()
 	if err != nil {
 		//  can't really happen
@@ -329,7 +330,7 @@ func (c *concreteSnap) ActiveIndex() int {
 	return -1
 }
 
-func (c *concreteSnap) Load(version string) (snappy.Part, error) {
+func (c *concreteSnap) Load(version string) (abstract.Part, error) {
 	yamlPath := filepath.Join(c.instdir, c.self.QualifiedName(), version, "meta", "package.yaml")
 	if !helpers.FileExists(yamlPath) {
 		return removed.New(c.self.Name, c.self.Origin, version, c.self.Type), nil
@@ -362,7 +363,7 @@ func (bag *PartBag) ActiveIndex() int {
 }
 
 // Load a Part from the PartBag
-func (bag *PartBag) Load(versionIdx int) (snappy.Part, error) {
+func (bag *PartBag) Load(versionIdx int) (abstract.Part, error) {
 	if bag == nil {
 		return nil, nil
 	}
@@ -378,7 +379,7 @@ func (bag *PartBag) Load(versionIdx int) (snappy.Part, error) {
 
 // LoadActive gets the active index and loads it.
 // If none active, returns a nil Part and ErrBadVersionIndex.
-func (bag *PartBag) LoadActive() (snappy.Part, error) {
+func (bag *PartBag) LoadActive() (abstract.Part, error) {
 	return bag.Load(bag.ActiveIndex())
 }
 
@@ -391,7 +392,7 @@ func (bag *PartBag) LoadActive() (snappy.Part, error) {
 // If not even a removed part can be loaded, something is wrong. Nil
 // is returned, but you're in trouble (did the filesystem just
 // disappear under us?).
-func (bag *PartBag) LoadBest() snappy.Part {
+func (bag *PartBag) LoadBest() abstract.Part {
 	if bag == nil {
 		return nil
 	}
@@ -425,7 +426,7 @@ func (bag *PartBag) LoadBest() snappy.Part {
 //
 // Also may panic if the remote part is nil and LoadBest can't load a
 // Part at all.
-func (bag *PartBag) Map(remotePart snappy.Part) map[string]string {
+func (bag *PartBag) Map(remotePart abstract.Part) map[string]string {
 	var version, update, rollback, icon, name, origin, _type, vendor, description string
 
 	if bag == nil && remotePart == nil {

--- a/pkg/removed/removed.go
+++ b/pkg/removed/removed.go
@@ -29,6 +29,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/ubuntu-core/snappy/part/abstract"
 	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/pkg/remote"
 	"github.com/ubuntu-core/snappy/progress"
@@ -48,7 +49,7 @@ type Removed struct {
 }
 
 // New removed package.
-func New(name, origin, version string, pkgType pkg.Type) snappy.Part {
+func New(name, origin, version string, pkgType pkg.Type) abstract.Part {
 	part := &Removed{
 		name:    name,
 		origin:  origin,
@@ -64,13 +65,13 @@ func New(name, origin, version string, pkgType pkg.Type) snappy.Part {
 	return part
 }
 
-// Name from the snappy.Part interface
+// Name from the abstract.Part interface
 func (r *Removed) Name() string { return r.name }
 
-// Version from the snappy.Part interface
+// Version from the abstract.Part interface
 func (r *Removed) Version() string { return r.version }
 
-// Description from the snappy.Part interface
+// Description from the abstract.Part interface
 func (r *Removed) Description() string {
 	if r.remote != nil {
 		return r.remote.Description
@@ -79,7 +80,7 @@ func (r *Removed) Description() string {
 	return ""
 }
 
-// Origin from the snappy.Part interface
+// Origin from the abstract.Part interface
 func (r *Removed) Origin() string {
 	if r.remote != nil {
 		return r.remote.Origin
@@ -90,7 +91,7 @@ func (r *Removed) Origin() string {
 	return r.origin
 }
 
-// Vendor from the snappy.Part interface
+// Vendor from the abstract.Part interface
 func (r *Removed) Vendor() string {
 	if r.remote != nil {
 		return r.remote.Publisher
@@ -99,24 +100,24 @@ func (r *Removed) Vendor() string {
 	return ""
 }
 
-// Hash from the snappy.Part interface
+// Hash from the abstract.Part interface
 func (r *Removed) Hash() string { return "" }
 
-// IsActive from the snappy.Part interface
+// IsActive from the abstract.Part interface
 func (r *Removed) IsActive() bool { return false }
 
-// IsInstalled from the snappy.Part interface
+// IsInstalled from the abstract.Part interface
 func (r *Removed) IsInstalled() bool { return false }
 
-// NeedsReboot from the snappy.Part interface
+// NeedsReboot from the abstract.Part interface
 func (r *Removed) NeedsReboot() bool { return false }
 
-// Date from the snappy.Part interface
+// Date from the abstract.Part interface
 func (r *Removed) Date() time.Time { return time.Time{} } // XXX: keep track of when the package was removed
-// Channel from the snappy.Part interface
+// Channel from the abstract.Part interface
 func (r *Removed) Channel() string { return "" }
 
-// Icon from the snappy.Part interface
+// Icon from the abstract.Part interface
 func (r *Removed) Icon() string {
 	if r.remote != nil {
 		return r.remote.IconURL
@@ -125,13 +126,13 @@ func (r *Removed) Icon() string {
 	return ""
 }
 
-// Type from the snappy.Part interface
+// Type from the abstract.Part interface
 func (r *Removed) Type() pkg.Type { return r.pkgType }
 
-// InstalledSize from the snappy.Part interface
+// InstalledSize from the abstract.Part interface
 func (r *Removed) InstalledSize() int64 { return -1 }
 
-// DownloadSize from the snappy.Part interface
+// DownloadSize from the abstract.Part interface
 func (r *Removed) DownloadSize() int64 {
 	if r.remote != nil {
 		return r.remote.DownloadSize
@@ -140,19 +141,19 @@ func (r *Removed) DownloadSize() int64 {
 	return -1
 }
 
-// Install from the snappy.Part interface
-func (r *Removed) Install(pb progress.Meter, flags snappy.InstallFlags) (name string, err error) {
+// Install from the abstract.Part interface
+func (r *Removed) Install(pb progress.Meter, flags pkg.InstallFlags) (name string, err error) {
 	return "", ErrRemoved
 }
 
-// Uninstall from the snappy.Part interface
+// Uninstall from the abstract.Part interface
 func (r *Removed) Uninstall(pb progress.Meter) error { return ErrRemoved }
 
-// Config from the snappy.Part interface
+// Config from the abstract.Part interface
 func (r *Removed) Config(configuration []byte) (newConfig string, err error) { return "", ErrRemoved }
 
-// SetActive from the snappy.Part interface
+// SetActive from the abstract.Part interface
 func (r *Removed) SetActive(bool, progress.Meter) error { return ErrRemoved }
 
-// Frameworks from the snappy.Part interface
+// Frameworks from the abstract.Part interface
 func (r *Removed) Frameworks() ([]string, error) { return nil, ErrRemoved }

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -25,6 +25,21 @@ import (
 	"encoding/json"
 )
 
+// InstallFlags can be used to pass additional flags to the install of a
+// snap
+type InstallFlags uint
+
+const (
+	// AllowUnauthenticated allows to install a snap even if it can not be authenticated
+	AllowUnauthenticated InstallFlags = 1 << iota
+	// InhibitHooks will ensure that the hooks are not run
+	InhibitHooks
+	// DoInstallGC will ensure that garbage collection is done
+	DoInstallGC
+	// AllowOEM allows the installation of OEM packages, this does not affect updates.
+	AllowOEM
+)
+
 // Type represents the kind of snap (app, core, frameworks, oem)
 type Type string
 

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -45,10 +45,10 @@ import (
 	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/part/local"
 	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/pkg/clickdeb"
 	"github.com/ubuntu-core/snappy/progress"
-	"github.com/ubuntu-core/snappy/snappy/installed"
 	"github.com/ubuntu-core/snappy/systemd"
 
 	"github.com/mvo5/goconfigparser"
@@ -296,7 +296,7 @@ func quoteEnvVar(envVar string) string {
 }
 
 func originFromBasedir(pkgPath string) string {
-	return installed.Path(pkgPath).Origin()
+	return local.Part(pkgPath).Origin()
 }
 
 func generateSnapBinaryWrapper(binary Binary, pkgPath, aaProfile string, m *packageYaml) (string, error) {
@@ -501,7 +501,7 @@ func stripGlobalRootDirImpl(dir string) string {
 	return dir[len(dirs.GlobalRootDir):]
 }
 
-func (m *packageYaml) addPackageServices(baseDir installed.Path, inhibitHooks bool, inter interacter) error {
+func (m *packageYaml) addPackageServices(baseDir local.Part, inhibitHooks bool, inter interacter) error {
 	for _, service := range m.ServiceYamls {
 		aaProfile, err := getSecurityProfile(m, service.Name, baseDir)
 		if err != nil {
@@ -589,7 +589,7 @@ func (m *packageYaml) addPackageServices(baseDir installed.Path, inhibitHooks bo
 	return nil
 }
 
-func (m *packageYaml) removePackageServices(baseDir installed.Path, inter interacter) error {
+func (m *packageYaml) removePackageServices(baseDir local.Part, inter interacter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
 	for _, service := range m.ServiceYamls {
 		serviceName := filepath.Base(generateServiceFileName(m, service))
@@ -631,7 +631,7 @@ func (m *packageYaml) removePackageServices(baseDir installed.Path, inter intera
 	return nil
 }
 
-func (m *packageYaml) addPackageBinaries(baseDir installed.Path) error {
+func (m *packageYaml) addPackageBinaries(baseDir local.Part) error {
 	if err := os.MkdirAll(dirs.SnapBinariesDir, 0755); err != nil {
 		return err
 	}
@@ -659,7 +659,7 @@ func (m *packageYaml) addPackageBinaries(baseDir installed.Path) error {
 	return nil
 }
 
-func (m *packageYaml) removePackageBinaries(baseDir installed.Path) error {
+func (m *packageYaml) removePackageBinaries(baseDir local.Part) error {
 	for _, binary := range m.Binaries {
 		os.Remove(generateBinaryName(m, binary))
 	}
@@ -704,8 +704,8 @@ func writeCompatManifestJSON(clickMetaDir string, manifestData []byte, origin st
 	return nil
 }
 
-func installClick(snapFile string, flags InstallFlags, inter progress.Meter, origin string) (name string, err error) {
-	allowUnauthenticated := (flags & AllowUnauthenticated) != 0
+func installClick(snapFile string, flags pkg.InstallFlags, inter progress.Meter, origin string) (name string, err error) {
+	allowUnauthenticated := (flags & pkg.AllowUnauthenticated) != 0
 	part, err := NewSnapPartFromSnapFile(snapFile, origin, allowUnauthenticated)
 	if err != nil {
 		return "", err

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -33,11 +33,11 @@ import (
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/part/local"
 	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/pkg/clickdeb"
 	"github.com/ubuntu-core/snappy/policy"
 	"github.com/ubuntu-core/snappy/progress"
-	"github.com/ubuntu-core/snappy/snappy/installed"
 	"github.com/ubuntu-core/snappy/systemd"
 )
 
@@ -232,7 +232,7 @@ func (s *SnapTestSuite) TestLocalSnapInstallDebsigVerifyPassesUnauth(c *C) {
 	defer func() { clickdeb.VerifyCmd = old }()
 
 	snapFile := makeTestSnapPackage(c, "")
-	name, err := installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	name, err := installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "foo")
 
@@ -499,7 +499,7 @@ version: 1.0
 type: oem
 icon: foo.svg
 vendor: Foo Bar <foo@example.com>`)
-	_, err := installClick(snapFile, AllowOEM, nil, testOrigin)
+	_, err := installClick(snapFile, pkg.AllowOEM, nil, testOrigin)
 	c.Assert(err, IsNil)
 
 	contentFile := filepath.Join(s.tempdir, "oem", "foo", "1.0", "bin", "foo")
@@ -515,7 +515,7 @@ version: 1.0
 type: oem
 icon: foo.svg
 vendor: Foo Bar <foo@example.com>`)
-	_, err := installClick(snapFile, AllowOEM, nil, testOrigin)
+	_, err := installClick(snapFile, pkg.AllowOEM, nil, testOrigin)
 	c.Assert(err, IsNil)
 	c.Assert(storeMinimalRemoteManifest("foo", "foo", testOrigin, "1.0", "", "remote-channel"), IsNil)
 
@@ -555,7 +555,7 @@ vendor: Foo Bar <foo@example.com>`)
 	c.Check(err, Equals, ErrOEMPackageInstall)
 
 	// this will cause chaos, but let's test if it works
-	_, err = installClick(snapFile, AllowOEM, nil, testOrigin)
+	_, err = installClick(snapFile, pkg.AllowOEM, nil, testOrigin)
 	c.Check(err, IsNil)
 }
 
@@ -565,11 +565,11 @@ icon: foo.svg
 vendor: Foo Bar <foo@example.com>
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
-	_, err := installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	_, err := installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 
 	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
-	_, err = installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	_, err = installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 
 	// ensure v2 is active
@@ -608,7 +608,7 @@ vendor: Foo Bar <foo@example.com>
 	canaryData := []byte("ni ni ni")
 
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
-	_, err = installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	_, err = installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	canaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "1.0", "canary.txt")
 	err = ioutil.WriteFile(canaryDataFile, canaryData, 0644)
@@ -617,7 +617,7 @@ vendor: Foo Bar <foo@example.com>
 	c.Assert(err, IsNil)
 
 	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
-	_, err = installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	_, err = installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	newCanaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "2.0", "canary.txt")
 	content, err := ioutil.ReadFile(newCanaryDataFile)
@@ -642,14 +642,14 @@ vendor: Foo Bar <foo@example.com>
 `
 	appDir := "foo." + testOrigin
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
-	_, err := installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	_, err := installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	canaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "1.0", "canary.txt")
 	err = ioutil.WriteFile(canaryDataFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
-	_, err = installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	_, err = installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	_, err = os.Stat(filepath.Join(dirs.SnapDataDir, appDir, "2.0", "canary.txt"))
 	c.Assert(err, IsNil)
@@ -678,14 +678,14 @@ integration:
 	appDir := "bar." + testOrigin
 	// install 1.0 and then upgrade to 2.0
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
-	_, err := installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	_, err := installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	canaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "1.0", "canary.txt")
 	err = ioutil.WriteFile(canaryDataFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
-	_, err = installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	_, err = installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	_, err = os.Stat(filepath.Join(dirs.SnapDataDir, appDir, "2.0", "canary.txt"))
 	c.Assert(err, IsNil)
@@ -723,14 +723,14 @@ integration:
 	appDir := "bar." + testOrigin
 	// install 1.0 and then upgrade to 2.0
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
-	_, err := installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	_, err := installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	canaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "1.0", "canary.txt")
 	err = ioutil.WriteFile(canaryDataFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
-	_, err = installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
+	_, err = installClick(snapFile, pkg.AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, NotNil)
 
 	// installing 2.0 will fail in the hooks,
@@ -846,7 +846,7 @@ binaries:
  - name: bin/bar
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
-	_, err := installClick(snapFile, AllowUnauthenticated, nil, "mvo")
+	_, err := installClick(snapFile, pkg.AllowUnauthenticated, nil, "mvo")
 	c.Assert(err, IsNil)
 
 	// ensure that the binary wrapper file go generated with the right
@@ -873,7 +873,7 @@ binaries:
  - name: bin/bar
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
-	_, err := installClick(snapFile, AllowUnauthenticated, nil, "mvo")
+	_, err := installClick(snapFile, pkg.AllowUnauthenticated, nil, "mvo")
 	c.Assert(err, IsNil)
 
 	// ensure that the binary wrapper file go generated with the right
@@ -886,7 +886,7 @@ binaries:
 
 	// and that it gets updated on upgrade
 	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
-	_, err = installClick(snapFile, AllowUnauthenticated, nil, "mvo")
+	_, err = installClick(snapFile, pkg.AllowUnauthenticated, nil, "mvo")
 	c.Assert(err, IsNil)
 	newSnapBin := filepath.Join(dirs.SnapAppsDir[len(dirs.GlobalRootDir):], "foo.mvo", "2.0", "bin", "bar")
 	content, err = ioutil.ReadFile(binaryWrapper)
@@ -903,7 +903,7 @@ services:
    start: bin/hello
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
-	_, err := installClick(snapFile, AllowUnauthenticated, nil, "mvo")
+	_, err := installClick(snapFile, pkg.AllowUnauthenticated, nil, "mvo")
 	c.Assert(err, IsNil)
 
 	servicesFile := filepath.Join(dirs.SnapServicesDir, "foo_service_1.0.service")
@@ -932,7 +932,7 @@ vendor: foo
 type: framework
 version: `
 	fmkFile := makeTestSnapPackage(c, fmkYaml+"1")
-	_, err := installClick(fmkFile, AllowUnauthenticated, inter, "")
+	_, err := installClick(fmkFile, pkg.AllowUnauthenticated, inter, "")
 	c.Assert(err, IsNil)
 
 	packageYaml := `name: foo
@@ -947,7 +947,7 @@ services:
    start: bin/bye
 version: `
 	snapFile := makeTestSnapPackage(c, packageYaml+"1.0")
-	_, err = installClick(snapFile, AllowUnauthenticated, inter, testOrigin)
+	_, err = installClick(snapFile, pkg.AllowUnauthenticated, inter, testOrigin)
 	c.Assert(err, IsNil)
 
 	c.Assert(helpers.FileExists(filepath.Join(dirs.SnapServicesDir, "foo_svc1_1.0.service")), Equals, true)
@@ -966,7 +966,7 @@ func (s *SnapTestSuite) TestSnappyHandleDependentServicesOnInstall(c *C) {
 	}
 
 	upFile := makeTestSnapPackage(c, fmkYaml+"2")
-	_, err := installClick(upFile, AllowUnauthenticated, inter, "")
+	_, err := installClick(upFile, pkg.AllowUnauthenticated, inter, "")
 	c.Assert(err, IsNil)
 	c.Check(cmdlog, DeepEquals, []string{"stop", "show", "stop", "show", "start", "start"})
 
@@ -995,7 +995,7 @@ func (s *SnapTestSuite) TestSnappyHandleDependentServicesOnInstallFailingToStop(
 	}
 
 	upFile := makeTestSnapPackage(c, fmkYaml+"2")
-	_, err := installClick(upFile, AllowUnauthenticated, inter, "")
+	_, err := installClick(upFile, pkg.AllowUnauthenticated, inter, "")
 	c.Check(err, Equals, anError)
 	c.Check(cmdlog, DeepEquals, []string{"stop", "show", "stop", "start"})
 
@@ -1023,7 +1023,7 @@ func (s *SnapTestSuite) TestSnappyHandleDependentServicesOnInstallFailingToStart
 	}
 
 	upFile := makeTestSnapPackage(c, fmkYaml+"2")
-	_, err := installClick(upFile, AllowUnauthenticated, inter, "")
+	_, err := installClick(upFile, pkg.AllowUnauthenticated, inter, "")
 	c.Assert(err, Equals, anError)
 	c.Check(cmdlog, DeepEquals, []string{
 		"stop", "show", "stop", "show", "start", "start", // <- this one fails
@@ -1056,7 +1056,7 @@ services:
    start: bin/hello
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
-	_, err := installClick(snapFile, InhibitHooks, nil, testOrigin)
+	_, err := installClick(snapFile, pkg.InhibitHooks, nil, testOrigin)
 	c.Assert(err, IsNil)
 
 	c.Assert(allSystemctl, HasLen, 0)
@@ -1118,7 +1118,7 @@ integration:
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
 
 	// install it
-	_, err := installClick(snapFile, InhibitHooks, nil, testOrigin)
+	_, err := installClick(snapFile, pkg.InhibitHooks, nil, testOrigin)
 	c.Assert(err, IsNil)
 
 	// verify we have the symlink
@@ -1137,7 +1137,7 @@ func (s *SnapTestSuite) TestAddPackageServicesStripsGlobalRootdir(c *C) {
 	c.Assert(err, IsNil)
 	m, err := parsePackageYamlFile(yamlFile)
 	c.Assert(err, IsNil)
-	baseDir := installed.Path(filepath.Dir(filepath.Dir(yamlFile)))
+	baseDir := local.Part(filepath.Dir(filepath.Dir(yamlFile)))
 	err = m.addPackageServices(baseDir, false, nil)
 	c.Assert(err, IsNil)
 
@@ -1166,7 +1166,7 @@ services:
 	c.Assert(err, IsNil)
 	m, err := parsePackageYamlFile(yamlFile)
 	c.Assert(err, IsNil)
-	baseDir := installed.Path(filepath.Dir(filepath.Dir(yamlFile)))
+	baseDir := local.Part(filepath.Dir(filepath.Dir(yamlFile)))
 	err = m.addPackageServices(baseDir, false, nil)
 	c.Assert(err, IsNil)
 
@@ -1188,7 +1188,7 @@ services:
 	c.Assert(err, IsNil)
 	m, err := parsePackageYamlFile(yamlFile)
 	c.Assert(err, IsNil)
-	baseDir := installed.Path(filepath.Dir(filepath.Dir(yamlFile)))
+	baseDir := local.Part(filepath.Dir(filepath.Dir(yamlFile)))
 	err = m.addPackageServices(baseDir, false, nil)
 	c.Assert(err, IsNil)
 
@@ -1206,7 +1206,7 @@ func (s *SnapTestSuite) TestAddPackageBinariesStripsGlobalRootdir(c *C) {
 	c.Assert(err, IsNil)
 	m, err := parsePackageYamlFile(yamlFile)
 	c.Assert(err, IsNil)
-	baseDir := installed.Path(filepath.Dir(filepath.Dir(yamlFile)))
+	baseDir := local.Part(filepath.Dir(filepath.Dir(yamlFile)))
 	err = m.addPackageBinaries(baseDir)
 	c.Assert(err, IsNil)
 
@@ -1502,7 +1502,7 @@ services:
 	m, err := parsePackageYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	inter := &MockProgressMeter{}
-	c.Check(m.removePackageServices(installed.Path(filepath.Dir(filepath.Dir(yamlFile))), inter), IsNil)
+	c.Check(m.removePackageServices(local.Part(filepath.Dir(filepath.Dir(yamlFile))), inter), IsNil)
 	c.Assert(len(inter.notified) > 0, Equals, true)
 	c.Check(inter.notified[len(inter.notified)-1], Equals, "wat_wat_42.service refused to stop, killing.")
 	c.Assert(len(sysdLog) >= 3, Equals, true)

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ubuntu-core/snappy/pkg/clickdeb"
 	"github.com/ubuntu-core/snappy/policy"
 	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy/installed"
 	"github.com/ubuntu-core/snappy/systemd"
 )
 
@@ -1136,7 +1137,7 @@ func (s *SnapTestSuite) TestAddPackageServicesStripsGlobalRootdir(c *C) {
 	c.Assert(err, IsNil)
 	m, err := parsePackageYamlFile(yamlFile)
 	c.Assert(err, IsNil)
-	baseDir := filepath.Dir(filepath.Dir(yamlFile))
+	baseDir := installed.Path(filepath.Dir(filepath.Dir(yamlFile)))
 	err = m.addPackageServices(baseDir, false, nil)
 	c.Assert(err, IsNil)
 
@@ -1165,7 +1166,7 @@ services:
 	c.Assert(err, IsNil)
 	m, err := parsePackageYamlFile(yamlFile)
 	c.Assert(err, IsNil)
-	baseDir := filepath.Dir(filepath.Dir(yamlFile))
+	baseDir := installed.Path(filepath.Dir(filepath.Dir(yamlFile)))
 	err = m.addPackageServices(baseDir, false, nil)
 	c.Assert(err, IsNil)
 
@@ -1187,7 +1188,7 @@ services:
 	c.Assert(err, IsNil)
 	m, err := parsePackageYamlFile(yamlFile)
 	c.Assert(err, IsNil)
-	baseDir := filepath.Dir(filepath.Dir(yamlFile))
+	baseDir := installed.Path(filepath.Dir(filepath.Dir(yamlFile)))
 	err = m.addPackageServices(baseDir, false, nil)
 	c.Assert(err, IsNil)
 
@@ -1205,7 +1206,7 @@ func (s *SnapTestSuite) TestAddPackageBinariesStripsGlobalRootdir(c *C) {
 	c.Assert(err, IsNil)
 	m, err := parsePackageYamlFile(yamlFile)
 	c.Assert(err, IsNil)
-	baseDir := filepath.Dir(filepath.Dir(yamlFile))
+	baseDir := installed.Path(filepath.Dir(filepath.Dir(yamlFile)))
 	err = m.addPackageBinaries(baseDir)
 	c.Assert(err, IsNil)
 
@@ -1501,7 +1502,7 @@ services:
 	m, err := parsePackageYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	inter := &MockProgressMeter{}
-	c.Check(m.removePackageServices(filepath.Dir(filepath.Dir(yamlFile)), inter), IsNil)
+	c.Check(m.removePackageServices(installed.Path(filepath.Dir(filepath.Dir(yamlFile))), inter), IsNil)
 	c.Assert(len(inter.notified) > 0, Equals, true)
 	c.Check(inter.notified[len(inter.notified)-1], Equals, "wat_wat_42.service refused to stop, killing.")
 	c.Assert(len(sysdLog) >= 3, Equals, true)

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -235,13 +235,13 @@ vendor: Foo Bar <foo@example.com>
 	}
 
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
-	n, err := installClick(snapFile, AllowUnauthenticated|AllowOEM, inter, testOrigin)
+	n, err := installClick(snapFile, pkg.AllowUnauthenticated|pkg.AllowOEM, inter, testOrigin)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, "foo")
 	c.Assert(storeMinimalRemoteManifest(qn, "foo", testOrigin, "1.0", "", "remote-channel"), IsNil)
 
 	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
-	n, err = installClick(snapFile, AllowUnauthenticated|AllowOEM, inter, testOrigin)
+	n, err = installClick(snapFile, pkg.AllowUnauthenticated|pkg.AllowOEM, inter, testOrigin)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, "foo")
 	c.Assert(storeMinimalRemoteManifest(qn, "foo", testOrigin, "2.0", "", "remote-channel"), IsNil)

--- a/snappy/config.go
+++ b/snappy/config.go
@@ -24,7 +24,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/ubuntu-core/snappy/snappy/installed"
+	"github.com/ubuntu-core/snappy/part/local"
 )
 
 // can be overriden by tests
@@ -36,7 +36,7 @@ var aaExec = "aa-exec"
 // This string can be empty.
 //
 // It returns the newConfig or an error
-func snapConfig(snapDir installed.Path, origin, rawConfig string) (newConfig string, err error) {
+func snapConfig(snapDir local.Part, origin, rawConfig string) (newConfig string, err error) {
 	if !snapDir.HasConfig() {
 		return "", ErrConfigNotFound
 	}

--- a/snappy/config.go
+++ b/snappy/config.go
@@ -21,10 +21,10 @@ package snappy
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
+
+	"github.com/ubuntu-core/snappy/snappy/installed"
 )
 
 // can be overriden by tests
@@ -36,13 +36,13 @@ var aaExec = "aa-exec"
 // This string can be empty.
 //
 // It returns the newConfig or an error
-func snapConfig(snapDir, origin, rawConfig string) (newConfig string, err error) {
-	configScript := filepath.Join(snapDir, "meta", "hooks", "config")
-	if _, err := os.Stat(configScript); err != nil {
+func snapConfig(snapDir installed.Path, origin, rawConfig string) (newConfig string, err error) {
+	if !snapDir.HasConfig() {
 		return "", ErrConfigNotFound
 	}
+	configScript := snapDir.ConfigScript()
 
-	part, err := NewInstalledSnapPart(filepath.Join(snapDir, "meta", "package.yaml"), origin)
+	part, err := NewInstalledSnapPart(snapDir.YamlPath(), origin)
 	if err != nil {
 		return "", ErrPackageNotFound
 	}

--- a/snappy/config_test.go
+++ b/snappy/config_test.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ubuntu-core/snappy/snappy/installed"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -60,7 +62,7 @@ config:
     key: value
 `
 
-func (s *SnapTestSuite) makeInstalledMockSnapWithConfig(c *C, configScript string, yamls ...string) (snapDir string, err error) {
+func (s *SnapTestSuite) makeInstalledMockSnapWithConfig(c *C, configScript string, yamls ...string) (snapDir installed.Path, err error) {
 	yamlFile, err := s.makeInstalledMockSnap(yamls...)
 	c.Assert(err, IsNil)
 	metaDir := filepath.Dir(yamlFile)
@@ -69,7 +71,7 @@ func (s *SnapTestSuite) makeInstalledMockSnapWithConfig(c *C, configScript strin
 	err = ioutil.WriteFile(filepath.Join(metaDir, "hooks", "config"), []byte(configScript), 0755)
 	c.Assert(err, IsNil)
 
-	snapDir = filepath.Dir(metaDir)
+	snapDir = installed.Path(filepath.Dir(metaDir))
 	return snapDir, nil
 }
 

--- a/snappy/config_test.go
+++ b/snappy/config_test.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ubuntu-core/snappy/snappy/installed"
+	"github.com/ubuntu-core/snappy/part/local"
 
 	. "gopkg.in/check.v1"
 )
@@ -62,7 +62,7 @@ config:
     key: value
 `
 
-func (s *SnapTestSuite) makeInstalledMockSnapWithConfig(c *C, configScript string, yamls ...string) (snapDir installed.Path, err error) {
+func (s *SnapTestSuite) makeInstalledMockSnapWithConfig(c *C, configScript string, yamls ...string) (snapDir local.Part, err error) {
 	yamlFile, err := s.makeInstalledMockSnap(yamls...)
 	c.Assert(err, IsNil)
 	metaDir := filepath.Dir(yamlFile)
@@ -71,7 +71,7 @@ func (s *SnapTestSuite) makeInstalledMockSnapWithConfig(c *C, configScript strin
 	err = ioutil.WriteFile(filepath.Join(metaDir, "hooks", "config"), []byte(configScript), 0755)
 	c.Assert(err, IsNil)
 
-	snapDir = installed.Path(filepath.Dir(metaDir))
+	snapDir = local.Part(filepath.Dir(metaDir))
 	return snapDir, nil
 }
 

--- a/snappy/firstboot_test.go
+++ b/snappy/firstboot_test.go
@@ -27,6 +27,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/ubuntu-core/snappy/part/abstract"
 	"github.com/ubuntu-core/snappy/pkg"
 )
 
@@ -99,8 +100,8 @@ func (s *FirstBootTestSuite) getOem() (*packageYaml, error) {
 
 func (s *FirstBootTestSuite) mockActiveSnapNamesByType() *fakePart {
 	fakeOem := fakePart{oemConfig: s.oemConfig, snapType: pkg.TypeOem}
-	activeSnapsByType = func(snapsTs ...pkg.Type) ([]Part, error) {
-		return []Part{&fakeOem}, nil
+	activeSnapsByType = func(snapsTs ...pkg.Type) ([]abstract.Part, error) {
+		return []abstract.Part{&fakeOem}, nil
 	}
 
 	return &fakeOem
@@ -108,7 +109,7 @@ func (s *FirstBootTestSuite) mockActiveSnapNamesByType() *fakePart {
 
 func (s *FirstBootTestSuite) mockActiveSnapByName() *fakePart {
 	fakeMyApp := fakePart{snapType: pkg.TypeApp}
-	activeSnapByName = func(needle string) Part {
+	activeSnapByName = func(needle string) abstract.Part {
 		return &fakeMyApp
 	}
 
@@ -137,7 +138,7 @@ func (s *FirstBootTestSuite) TestTwoRuns(c *C) {
 }
 
 func (s *FirstBootTestSuite) TestNoErrorWhenNoOEM(c *C) {
-	activeSnapsByType = func(snapsTs ...pkg.Type) ([]Part, error) {
+	activeSnapsByType = func(snapsTs ...pkg.Type) ([]abstract.Part, error) {
 		return nil, nil
 	}
 

--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/partition"
+	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/progress"
 )
 
@@ -46,12 +47,12 @@ func makeCloudInitMetaData(c *C, content string) string {
 
 func (s *SnapTestSuite) TestInstallInstall(c *C) {
 	snapFile := makeTestSnapPackage(c, "")
-	name, err := Install(snapFile, AllowUnauthenticated|DoInstallGC, &progress.NullProgress{})
+	name, err := Install(snapFile, pkg.AllowUnauthenticated|pkg.DoInstallGC, &progress.NullProgress{})
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "foo")
 }
 
-func (s *SnapTestSuite) installThree(c *C, flags InstallFlags) {
+func (s *SnapTestSuite) installThree(c *C, flags pkg.InstallFlags) {
 	dirs.SnapDataHomeGlob = filepath.Join(s.tempdir, "home", "*", "apps")
 	homeDir := filepath.Join(s.tempdir, "home", "user1", "apps")
 	homeData := filepath.Join(homeDir, "foo", "1.0")
@@ -77,7 +78,7 @@ vendor: Foo Bar <foo@example.com>
 
 // check that on install we remove all but the two newest package versions
 func (s *SnapTestSuite) TestClickInstallGCSimple(c *C) {
-	s.installThree(c, AllowUnauthenticated|DoInstallGC)
+	s.installThree(c, pkg.AllowUnauthenticated|pkg.DoInstallGC)
 
 	globs, err := filepath.Glob(filepath.Join(dirs.SnapAppsDir, "foo.sideload", "*"))
 	c.Check(err, IsNil)
@@ -89,9 +90,9 @@ func (s *SnapTestSuite) TestClickInstallGCSimple(c *C) {
 	c.Check(globs, HasLen, 3+1) // +1 for "current"
 }
 
-// check that if flags does not include DoInstallGC, no gc is done
+// check that if flags does not include pkg.DoInstallGC, no gc is done
 func (s *SnapTestSuite) TestClickInstallGCSuppressed(c *C) {
-	s.installThree(c, AllowUnauthenticated)
+	s.installThree(c, pkg.AllowUnauthenticated)
 
 	globs, err := filepath.Glob(filepath.Join(dirs.SnapAppsDir, "foo.sideload", "*"))
 	c.Assert(err, IsNil)
@@ -186,7 +187,7 @@ func (s *SnapTestSuite) TestInstallAppPackageNameFails(c *C) {
 
 func (s *SnapTestSuite) TestUpdate(c *C) {
 	snapPackagev1 := makeTestSnapPackage(c, "name: foo\nversion: 1\nvendor: foo")
-	name, err := Install(snapPackagev1, AllowUnauthenticated|DoInstallGC, &progress.NullProgress{})
+	name, err := Install(snapPackagev1, pkg.AllowUnauthenticated|pkg.DoInstallGC, &progress.NullProgress{})
 	c.Assert(err, IsNil)
 	c.Assert(name, Equals, "foo")
 

--- a/snappy/installed/path.go
+++ b/snappy/installed/path.go
@@ -17,6 +17,28 @@
  *
  */
 
+/* FIXME:
+Feedback
+
+@mvogt This looks more like a Snap than a Path
+@mvogt InstalledSnap, maybe
+@mvogt For a path, I would expect focus on the path itself, but we (rightfuly) see much richer functionality there
+
+John Lenton
+@mvogt @niemeyer if packageYaml were in a package, this would live in that package
+John Lenton
+@mvogt so I propose you make it that package, even if it doesn't have packageYaml yet
+
+Gustavo Niemeyer
+@mvogt Alright, so here is a more complete high-level suggestion
+@mvogt The concept hints at something really interesting, but it feels like it isn't really a Path that you are after. For example, IsActive isn't really a property of a path. This looks to me like a first class abstraction for installed snaps as mentioned above.
+@mvogt The location for this might be something along the lines of snappy.InstalledSnap, because this is really something that is tied in to the snappy runtime behavior, except today snappy is that catch all package that we are trying to get rid of.
+@mvogt I suggest creating a top-level snapsys package whose job is to hold the public snappy-specific functionality that manipulates a local snappy system. In this package we'll hold the sort of higher level abstraction that we were talking about in the context of John's locking work.
+@mvogt Once we clean up the snappy package completely, we can move this there.. or perhaps we just keep snapsys, which is not such a bad name and snappy/snapsys ends up better than snappy/snappy..
+@mvogt Then, I think we can make that API more high-level over time.. it's fine by me if that's not done right now, though
+@mvogt For example, rather than returning the path to the metadata yaml file, why don't we offer a structure out with those details already parsed?
+*/
+
 package installed
 
 import (

--- a/snappy/installed/path.go
+++ b/snappy/installed/path.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package installed
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ubuntu-core/snappy/helpers"
+)
+
+// InstalledPath represents a installed snap path
+type Path string
+
+func (i Path) HasConfig() bool {
+	return helpers.FileExists(i.ConfigScript())
+}
+
+func (i Path) ConfigScript() string {
+	return filepath.Join(string(i), "meta", "hooks", "config")
+}
+
+func (i Path) Origin() string {
+	ext := filepath.Ext(filepath.Dir(filepath.Clean(string(i))))
+	if len(ext) < 2 {
+		return ""
+	}
+
+	return ext[1:]
+}
+
+func (i Path) YamlPath() string {
+	return filepath.Join(string(i), "meta", "package.yaml")
+}
+
+func (i Path) ReadmePath() string {
+	return filepath.Join(string(i), "meta", "readme.md")
+}
+
+func (i Path) HashesPath() string {
+	return filepath.Join(string(i), "meta", "hashes.yaml")
+}
+
+func (i Path) Version() string {
+	return filepath.Base(string(i))
+}
+
+func (i Path) Size() int64 {
+	// FIXME: cache this at install time maybe?
+	totalSize := int64(0)
+	f := func(_ string, info os.FileInfo, err error) error {
+		totalSize += info.Size()
+		return err
+	}
+	filepath.Walk(string(i), f)
+	return totalSize
+}
+
+func (i Path) Date() time.Time {
+	st, err := os.Stat(string(i))
+	if err != nil {
+		return time.Time{}
+	}
+
+	return st.ModTime()
+}
+
+func (i Path) RemoveAll() error {
+	return os.RemoveAll(string(i))
+}
+
+func (i Path) IsActive() (bool, error) {
+	allVersionsDir := filepath.Dir(string(i))
+	p, err := filepath.EvalSymlinks(filepath.Join(allVersionsDir, "current"))
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+
+	return p == string(i), nil
+}

--- a/snappy/parts_test.go
+++ b/snappy/parts_test.go
@@ -27,6 +27,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/part/abstract"
 	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/progress"
 )
@@ -73,7 +74,7 @@ vendor: example.com`)
 	makeSnapActive(yamlPath)
 
 	type T struct {
-		f func(Part) string
+		f func(abstract.Part) string
 		t pkg.Type
 		n string
 	}

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -676,8 +676,10 @@ write
 	err = GeneratePolicyFromFile(mockPackageYamlFn, false)
 	c.Assert(err, IsNil)
 
+	ip := filepath.Dir(filepath.Dir(mockPackageYamlFn))
+
 	// nothing changed, compare is happy
-	err = CompareGeneratePolicyFromFile(mockPackageYamlFn)
+	err = CompareGeneratePolicyFromFile(ip)
 	c.Assert(err, IsNil)
 
 	// now change the templates
@@ -685,7 +687,7 @@ write
 ###POLICYGROUPS###
 `))
 	// ...and ensure that the difference is found
-	err = CompareGeneratePolicyFromFile(mockPackageYamlFn)
+	err = CompareGeneratePolicyFromFile(ip)
 	c.Assert(err, ErrorMatches, "policy differs.*")
 }
 

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -32,12 +32,13 @@ import (
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/part/abstract"
+	"github.com/ubuntu-core/snappy/part/local"
 	"github.com/ubuntu-core/snappy/partition"
 	"github.com/ubuntu-core/snappy/pkg"
 	"github.com/ubuntu-core/snappy/pkg/clickdeb"
 	"github.com/ubuntu-core/snappy/policy"
 	"github.com/ubuntu-core/snappy/release"
-	"github.com/ubuntu-core/snappy/snappy/installed"
 	"github.com/ubuntu-core/snappy/systemd"
 
 	. "gopkg.in/check.v1"
@@ -509,7 +510,7 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryAliasSearch(c *C) {
 	c.Assert(alias, DeepEquals, parts[0])
 }
 func mockActiveSnapIterByType(mockSnaps []string) {
-	ActiveSnapIterByType = func(f func(Part) string, snapTs ...pkg.Type) (res []string, err error) {
+	ActiveSnapIterByType = func(f func(abstract.Part) string, snapTs ...pkg.Type) (res []string, err error) {
 		return mockSnaps, nil
 	}
 }
@@ -1238,8 +1239,8 @@ binaries:
 
 	pb := &MockProgressMeter{}
 	m, err := parsePackageYamlData([]byte(yaml), false)
-	part := &SnapPart{m: m, origin: testOrigin, basedir: installed.Path(d1)}
-	c.Assert(part.RefreshDependentsSecurity(&SnapPart{basedir: installed.Path(d2)}, pb), IsNil)
+	part := &SnapPart{m: m, origin: testOrigin, basedir: local.Part(d1)}
+	c.Assert(part.RefreshDependentsSecurity(&SnapPart{basedir: local.Part(d2)}, pb), IsNil)
 	// TODO: verify it was updated
 }
 
@@ -1303,7 +1304,7 @@ func (s *SnapTestSuite) TestNeedsAppArmorUpdatePolicyAbsent(c *C) {
 func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateService(c *C) {
 	// if one of the services needs updating, it's updated and returned
 	svc := ServiceYaml{Name: "svc", SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"}}
-	part := &SnapPart{m: &packageYaml{Name: "part", ServiceYamls: []ServiceYaml{svc}, Version: "42"}, origin: testOrigin, basedir: installed.Path(filepath.Join(dirs.SnapAppsDir, "part."+testOrigin, "42"))}
+	part := &SnapPart{m: &packageYaml{Name: "part", ServiceYamls: []ServiceYaml{svc}, Version: "42"}, origin: testOrigin, basedir: local.Part(filepath.Join(dirs.SnapAppsDir, "part."+testOrigin, "42"))}
 	err := part.RequestSecurityPolicyUpdate(nil, map[string]bool{"foo": true})
 	c.Assert(err, NotNil)
 }
@@ -1311,7 +1312,7 @@ func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateService(c *C) {
 func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateBinary(c *C) {
 	// if one of the binaries needs updating, the part needs updating
 	bin := Binary{Name: "echo", SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"}}
-	part := &SnapPart{m: &packageYaml{Name: "part", Binaries: []Binary{bin}, Version: "42"}, origin: testOrigin, basedir: installed.Path(filepath.Join(dirs.SnapAppsDir, "part."+testOrigin, "42"))}
+	part := &SnapPart{m: &packageYaml{Name: "part", Binaries: []Binary{bin}, Version: "42"}, origin: testOrigin, basedir: local.Part(filepath.Join(dirs.SnapAppsDir, "part."+testOrigin, "42"))}
 	err := part.RequestSecurityPolicyUpdate(nil, map[string]bool{"foo": true})
 	c.Check(err, NotNil) // XXX: we should do better than this
 }

--- a/snappy/sort.go
+++ b/snappy/sort.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/part/abstract"
 )
 
 const (
@@ -198,7 +199,7 @@ func (bv ByVersion) Len() int {
 }
 
 // BySnapVersion provides a sort interface
-type BySnapVersion []Part
+type BySnapVersion []abstract.Part
 
 func (bv BySnapVersion) Less(a, b int) bool {
 	return (VersionCompare(bv[a].Version(), bv[b].Version()) < 0)

--- a/snappy/sort_test.go
+++ b/snappy/sort_test.go
@@ -25,6 +25,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/part/abstract"
 	"github.com/ubuntu-core/snappy/pkg/remote"
 )
 
@@ -83,7 +84,7 @@ func (s *SortTestSuite) TestSort(c *C) {
 }
 
 func (s *SortTestSuite) TestSortSnaps(c *C) {
-	snaps := []Part{
+	snaps := []abstract.Part{
 		&RemoteSnapPart{pkg: remote.Snap{Version: "2.0"}},
 		&RemoteSnapPart{pkg: remote.Snap{Version: "1.0"}},
 	}


### PR DESCRIPTION
This is a strawman branch to see if this change makes sense. The idea is to make a type of the InstalledPath of a snap to abstract it further. Please let me know what you think about the general approach and also about suggestions for the name and place of the installedpath.go code.
