### PR TITLE
snapstate: move next-auto-refresh-time into the config of "core"

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -50,6 +50,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/transaction"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -1421,13 +1422,13 @@ func getSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	s := c.d.overlord.State()
 	s.Lock()
-	transaction := configstate.NewTransaction(s)
+	tr := transaction.NewTransaction(s)
 	s.Unlock()
 
 	currentConfValues := make(map[string]interface{})
 	for _, key := range keys {
 		var value interface{}
-		if err := transaction.Get(snapName, key, &value); err != nil {
+		if err := tr.Get(snapName, key, &value); err != nil {
 			return BadRequest("%s", err)
 		}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -53,7 +53,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/transaction"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -2127,10 +2127,10 @@ func (s *apiSuite) TestGetConfSingleKey(c *check.C) {
 
 	// Set a config that we'll get in a moment
 	d.overlord.State().Lock()
-	transaction := configstate.NewTransaction(d.overlord.State())
-	transaction.Set("test-snap", "test-key1", "test-value1")
-	transaction.Set("test-snap", "test-key2", "test-value2")
-	transaction.Commit()
+	tr := transaction.NewTransaction(d.overlord.State())
+	tr.Set("test-snap", "test-key1", "test-value1")
+	tr.Set("test-snap", "test-key2", "test-value2")
+	tr.Commit()
 	d.overlord.State().Unlock()
 
 	result := s.runGetConf(c, []string{"test-key1"})

--- a/overlord/configstate/handler.go
+++ b/overlord/configstate/handler.go
@@ -19,7 +19,10 @@
 
 package configstate
 
-import "github.com/snapcore/snapd/overlord/hookstate"
+import (
+	"github.com/snapcore/snapd/overlord/configstate/transaction"
+	"github.com/snapcore/snapd/overlord/hookstate"
+)
 
 // configureHandler is the handler for the configure hook.
 type configureHandler struct {
@@ -32,23 +35,23 @@ type cachedTransaction struct{}
 
 // ContextTransaction retrieves the transaction cached within the context (and
 // creates one if it hasn't already been cached).
-func ContextTransaction(context *hookstate.Context) *Transaction {
+func ContextTransaction(context *hookstate.Context) *transaction.Transaction {
 	// Check for one already cached
-	transaction, ok := context.Cached(cachedTransaction{}).(*Transaction)
+	tr, ok := context.Cached(cachedTransaction{}).(*transaction.Transaction)
 	if ok {
-		return transaction
+		return tr
 	}
 
 	// It wasn't already cached, so create and cache a new one
-	transaction = NewTransaction(context.State())
+	tr = transaction.NewTransaction(context.State())
 
 	context.OnDone(func() error {
-		transaction.Commit()
+		tr.Commit()
 		return nil
 	})
 
-	context.Cache(cachedTransaction{}, transaction)
-	return transaction
+	context.Cache(cachedTransaction{}, tr)
+	return tr
 }
 
 func newConfigureHandler(context *hookstate.Context) hookstate.Handler {

--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -20,6 +20,8 @@
 package configstate_test
 
 import (
+	"testing"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/overlord/configstate"
@@ -28,6 +30,8 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
+
+func TestConfigState(t *testing.T) { TestingT(t) }
 
 type configureHandlerSuite struct {
 	context *hookstate.Context

--- a/overlord/configstate/transaction/transaction.go
+++ b/overlord/configstate/transaction/transaction.go
@@ -17,7 +17,7 @@
  *
  */
 
-package configstate
+package transaction
 
 import (
 	"encoding/json"

--- a/overlord/configstate/transaction/transaction_test.go
+++ b/overlord/configstate/transaction/transaction_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package configstate_test
+package transaction_test
 
 import (
 	"encoding/json"
@@ -26,16 +26,16 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/transaction"
 	"github.com/snapcore/snapd/overlord/state"
 	"strings"
 )
 
-func TestConfigState(t *testing.T) { TestingT(t) }
+func TestT(t *testing.T) { TestingT(t) }
 
 type transactionSuite struct {
 	state       *state.State
-	transaction *configstate.Transaction
+	transaction *transaction.Transaction
 }
 
 var _ = Suite(&transactionSuite{})
@@ -44,7 +44,7 @@ func (s *transactionSuite) SetUpTest(c *C) {
 	s.state = state.New(nil)
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.transaction = configstate.NewTransaction(s.state)
+	s.transaction = transaction.NewTransaction(s.state)
 }
 
 type setGetOp string
@@ -163,7 +163,7 @@ func (s *transactionSuite) TestSetGet(c *C) {
 	for _, test := range setGetTests {
 		c.Logf("-----")
 		s.state.Set("config", map[string]interface{}{})
-		t := configstate.NewTransaction(s.state)
+		t := transaction.NewTransaction(s.state)
 		snap := "core"
 		for _, op := range test {
 			c.Logf("%s", op)
@@ -190,7 +190,7 @@ func (s *transactionSuite) TestSetGet(c *C) {
 						continue
 					}
 					if expected == "-" {
-						if !configstate.IsNoOption(err) {
+						if !transaction.IsNoOption(err) {
 							c.Fatalf("Expected %q key to not exist, but it has value %v", k, obtained)
 						}
 						c.Assert(err, ErrorMatches, fmt.Sprintf("snap %q has no %q configuration option", snap, k))
@@ -269,7 +269,7 @@ func (s *transactionSuite) TestGetUnmarshalError(c *C) {
 	c.Check(s.transaction.Set("test-snap", "foo", "good"), IsNil)
 	s.transaction.Commit()
 
-	transaction := configstate.NewTransaction(s.state)
+	transaction := transaction.NewTransaction(s.state)
 	c.Check(transaction.Set("test-snap", "foo", "break"), IsNil)
 
 	// Pristine state is good, value in the transaction breaks.

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -44,7 +44,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/transaction"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -618,7 +618,7 @@ func getSerialRequestConfig(t *state.Task) (*serialRequestConfig, error) {
 	}
 	gadgetName := gadgetInfo.Name()
 
-	tr := configstate.NewTransaction(t.State())
+	tr := transaction.NewTransaction(t.State())
 	var svcURL string
 	err = tr.GetMaybe(gadgetName, "device-service.url", &svcURL)
 	if err != nil {

--- a/overlord/hookstate/ctlcmd/get.go
+++ b/overlord/hookstate/ctlcmd/get.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/transaction"
 )
 
 type getCommand struct {
@@ -75,15 +76,15 @@ func (c *getCommand) Execute(args []string) error {
 
 	patch := make(map[string]interface{})
 	context.Lock()
-	transaction := configstate.ContextTransaction(context)
+	tr := configstate.ContextTransaction(context)
 	context.Unlock()
 
 	for _, key := range c.Positional.Keys {
 		var value interface{}
-		err := transaction.Get(c.context().SnapName(), key, &value)
+		err := tr.Get(c.context().SnapName(), key, &value)
 		if err == nil {
 			patch[key] = value
-		} else if configstate.IsNoOption(err) {
+		} else if transaction.IsNoOption(err) {
 			if !c.Typed {
 				value = ""
 			}

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -20,7 +20,7 @@
 package ctlcmd_test
 
 import (
-	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/transaction"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
@@ -53,9 +53,9 @@ func (s *getSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// Initialize configuration
-	transaction := configstate.NewTransaction(state)
-	transaction.Set("test-snap", "initial-key", "initial-value")
-	transaction.Commit()
+	tr := transaction.NewTransaction(state)
+	tr.Set("test-snap", "initial-key", "initial-value")
+	tr.Commit()
 }
 
 var getTests = []struct {
@@ -106,10 +106,10 @@ func (s *getSuite) TestGetTests(c *C) {
 		c.Check(err, IsNil)
 
 		// Initialize configuration
-		t := configstate.NewTransaction(state)
-		t.Set("test-snap", "test-key1", "test-value1")
-		t.Set("test-snap", "test-key2", 2)
-		t.Commit()
+		tr := transaction.NewTransaction(state)
+		tr.Set("test-snap", "test-key1", "test-value1")
+		tr.Set("test-snap", "test-key2", 2)
+		tr.Commit()
 
 		state.Unlock()
 

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -20,7 +20,7 @@
 package ctlcmd_test
 
 import (
-	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/transaction"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
@@ -65,11 +65,11 @@ func (s *setSuite) TestCommand(c *C) {
 
 	// Verify that the previous set doesn't modify the global state
 	s.mockContext.State().Lock()
-	transaction := configstate.NewTransaction(s.mockContext.State())
+	tr := transaction.NewTransaction(s.mockContext.State())
 	s.mockContext.State().Unlock()
 	var value string
-	c.Check(transaction.Get("test-snap", "foo", &value), ErrorMatches, ".*snap.*has no.*configuration.*")
-	c.Check(transaction.Get("test-snap", "baz", &value), ErrorMatches, ".*snap.*has no.*configuration.*")
+	c.Check(tr.Get("test-snap", "foo", &value), ErrorMatches, ".*snap.*has no.*configuration.*")
+	c.Check(tr.Get("test-snap", "baz", &value), ErrorMatches, ".*snap.*has no.*configuration.*")
 
 	// Notify the context that we're done. This should save the config.
 	s.mockContext.Lock()
@@ -77,20 +77,20 @@ func (s *setSuite) TestCommand(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify that the global config has been updated.
-	transaction = configstate.NewTransaction(s.mockContext.State())
-	c.Check(transaction.Get("test-snap", "foo", &value), IsNil)
+	tr = transaction.NewTransaction(s.mockContext.State())
+	c.Check(tr.Get("test-snap", "foo", &value), IsNil)
 	c.Check(value, Equals, "bar")
-	c.Check(transaction.Get("test-snap", "baz", &value), IsNil)
+	c.Check(tr.Get("test-snap", "baz", &value), IsNil)
 	c.Check(value, Equals, "qux")
 }
 
 func (s *setSuite) TestCommandSavesDeltasOnly(c *C) {
 	// Setup an initial configuration
 	s.mockContext.State().Lock()
-	transaction := configstate.NewTransaction(s.mockContext.State())
-	transaction.Set("test-snap", "test-key1", "test-value1")
-	transaction.Set("test-snap", "test-key2", "test-value2")
-	transaction.Commit()
+	tr := transaction.NewTransaction(s.mockContext.State())
+	tr.Set("test-snap", "test-key1", "test-value1")
+	tr.Set("test-snap", "test-key2", "test-value2")
+	tr.Commit()
 	s.mockContext.State().Unlock()
 
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "test-key2=test-value3"})
@@ -104,11 +104,11 @@ func (s *setSuite) TestCommandSavesDeltasOnly(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify that the global config has been updated, but only test-key2
-	transaction = configstate.NewTransaction(s.mockContext.State())
+	tr = transaction.NewTransaction(s.mockContext.State())
 	var value string
-	c.Check(transaction.Get("test-snap", "test-key1", &value), IsNil)
+	c.Check(tr.Get("test-snap", "test-key1", &value), IsNil)
 	c.Check(value, Equals, "test-value1")
-	c.Check(transaction.Get("test-snap", "test-key2", &value), IsNil)
+	c.Check(tr.Get("test-snap", "test-key2", &value), IsNil)
 	c.Check(value, Equals, "test-value3")
 }
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate/transaction"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -420,8 +421,9 @@ func (m *SnapManager) ensureRefreshes() error {
 	defer m.state.Unlock()
 
 	var nextRefresh time.Time
-	err := m.state.Get("next-auto-refresh-time", &nextRefresh)
-	if err != nil && err != state.ErrNoState {
+	tr := transaction.NewTransaction(m.state)
+	err := tr.Get("core", "next-auto-refresh-time", &nextRefresh)
+	if err != nil && !transaction.IsNoOption(err) {
 		return err
 	}
 
@@ -1143,7 +1145,10 @@ func (m *SnapManager) startSnapServices(t *state.Task, _ *tomb.Tomb) error {
 func scheduleNextRefresh(st *state.State) time.Time {
 	randomness := rand.Int63n(int64(refreshRandomness))
 	nextRefreshTime := time.Now().Add(refreshInterval).Add(time.Duration(randomness))
-	st.Set("next-auto-refresh-time", nextRefreshTime)
+
+	tr := transaction.NewTransaction(st)
+	tr.Set("core", "next-auto-refresh-time", nextRefreshTime)
+	tr.Commit()
 
 	return nextRefreshTime
 }


### PR DESCRIPTION
(build on top of https://github.com/snapcore/snapd/pull/2558)

This is a straw-man branch to gather feedback on how to control the next snapd auto refresh. The code is a bit messy (i.e. transaction.NewTransaction is bad, the name transaction for the configstate/transaction is not idea etc). But hopefully its straightfoward to get the idea.

This branch explores the idea of using the normal `snap {get,set}` primitives for this. The idea is the following:
- 1a) the `next-auto-refresh-time` is a config under the core snap
- 1b) we add a hook to the core snap that will check that the policy for the next-auto-refresh delay is honoured (e.g. not more than 24h after the last refresh)
- 1c) users or programs can use `snap set core next-auto-refresh-time=2014-01-09T20:32` to control the next auto-refresh

A variation of this idea is to have a pseudo `snapd` snap config that is not using a hook but `snapd` internal validation
- 2a) the `next-auto-refresh-time` is a config under the pseudo `snapd` snap
- 2b) we have internal code in `configstate.Set` that checks for the pseudo `snapd` config and instead of calling a hook we do internal versification (also useful when setting bootconfig for e.g. config.txt for the pi2)
- 2c) same as above (1c)

Later we can also use a similar mechanism for update schedule. I.e. soemthing like: `snap set core updates.schedule 3:00-7:00,22:00-23:30` to scheduel updates only between 3 to 7 in the morning and 22 to 23:30 in the night.
