### PR TITLE
Differentiate denied and not found

### DIFF
--- a/cmd/snapd-aa-prompt-ui/snapd-aa-prompt-ui-gtk
+++ b/cmd/snapd-aa-prompt-ui/snapd-aa-prompt-ui-gtk
@@ -66,6 +66,7 @@ class Agent(dbus.service.Object):
         dialog = PromptDialog(app, icon, path, operation)
         res = dialog.run()
         if res == PromptDialog.RESPONSE_ALLOW:
+            extra_constraints["allow-directory"] = "yes"
             prompt_allow = True
         elif res == PromptDialog.RESPONSE_DENY:
             extra_constraints["always-prompt"] = "yes"

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -108,7 +108,7 @@ func (pd *PromptsDB) Set(req *notifier.Request, allow bool, extras map[string]st
 	if !osutil.IsDirectory(path) {
 		path = filepath.Dir(path)
 	}
-	if alreadyAllowed, _ := findPathInSubdirs(allowWithSubdirs, path); alreadyAllowed {
+	if alreadyAllowed, err := findPathInSubdirs(allowWithSubdirs, path); err == nil && alreadyAllowed {
 		return nil
 	}
 	allowWithSubdirs[path] = allow

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -108,7 +108,7 @@ func (pd *PromptsDB) Set(req *notifier.Request, allow bool, extras map[string]st
 	if !osutil.IsDirectory(path) {
 		path = filepath.Dir(path)
 	}
-	if alreadyAllowed, err := findPathInSubdirs(allowWithSubdirs, path); err == nil && alreadyAllowed {
+	if alreadyAllowed, err := findPathInSubdirs(allowWithSubdirs, path); err == nil && !(alreadyAllowed ^ allow) {
 		return nil
 	}
 	allowWithSubdirs[path] = allow

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -108,7 +108,11 @@ func (pd *PromptsDB) Set(req *notifier.Request, allow bool, extras map[string]st
 	if !osutil.IsDirectory(path) {
 		path = filepath.Dir(path)
 	}
-	if alreadyAllowed, err := findPathInSubdirs(allowWithSubdirs, path); err == nil && !(alreadyAllowed ^ allow) {
+	alreadyAllowed, err := findPathInSubdirs(allowWithSubdirs, path)
+	if err != nil && err != ErrNoSavedDecision {
+		return err
+	}
+	if err == nil && (alreadyAllowed == allow) {
 		return nil
 	}
 	allowWithSubdirs[path] = allow

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -105,7 +105,7 @@ func (pd *PromptsDB) Set(req *notifier.Request, allow bool, extras map[string]st
 	allowWithSubdirs := pd.PathsForUidAndLabel(req.SubjectUid, req.Label)
 
 	path := req.Path
-	if !osutil.IsDirectory(path) {
+	if ((allow && extras["allow-directory"] == "yes") || (!allow && extras["deny-directory"] == "yes")) && !osutil.IsDirectory(path) {
 		path = filepath.Dir(path)
 	}
 	alreadyAllowed, err := findPathInSubdirs(allowWithSubdirs, path)


### PR DESCRIPTION
This change makes the `Get()` method of prompt response storage properly report whether an access denial is due to a `false` value in the response database or whether there is no response found.

Additionally, there was previously no way to change an allow to a deny in the database. Presumably, this is because if a path is allowed, the user will not be prompted again. However, if the `Set()` function is called with an allow value of `false` and the database previously holds a `true` value, I think that it should be successfully changed to `false` rather than returning early.