### PR TITLE
prompting/storage: split db into file, dir, and subdir decisions

### DIFF
--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -96,19 +96,6 @@ outside:
 	return false, ErrNoSavedDecision, "", ""
 }
 
-func findPathInSubdirs(paths map[string]bool, path string) (bool, error) {
-	for {
-		if allow, exists := paths[path]; exists {
-			return allow, nil
-		}
-		path = filepath.Dir(path)
-		if path == "/" || path == "." {
-			break
-		}
-	}
-	return false, ErrNoSavedDecision
-}
-
 // TODO: unexport
 func (pd *PromptsDB) MapsForUidAndLabel(uid uint32, label string) *labelDB {
 	userEntries := pd.PerUser[uid]

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -47,9 +47,6 @@ func findPathInLabelDB(db *labelDB, path string) (bool, error, string, string) {
 	// string: ("allow" | "allow-with-dir" | "allow-with-subdir") -- json name of map which contained match
 	// string: matching path current in the db
 	path = filepath.Clean(path)
-	if strings.HasSuffix(path, "/") {
-		path = filepath.Dir(path)
-	}
 	storedAllow := true
 	which := ""
 	var err error
@@ -158,10 +155,11 @@ func (pd *PromptsDB) Set(req *notifier.Request, allow bool, extras map[string]st
 	// should it be removed since we want to "always prompt"?
 	labelEntries := pd.MapsForUidAndLabel(req.SubjectUid, req.Label)
 
-	path := filepath.Clean(req.Path)
+	path := req.Path
 	if strings.HasSuffix(path, "/") || (((allow && (extras["allow-directory"] == "yes" || extras["allow-subdirectories"] == "yes")) || (!allow && (extras["deny-directory"] == "yes" || extras["deny-subdirectories"] == "yes"))) && !osutil.IsDirectory(path)) {
 		path = filepath.Dir(path)
 	}
+	path = filepath.Clean(path)
 	alreadyAllowed, err, which, matchingPath := findPathInLabelDB(labelEntries, path)
 	if err != nil && err != ErrNoSavedDecision {
 		return err

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -181,27 +181,27 @@ func (pd *PromptsDB) Set(req *notifier.Request, allow bool, extras map[string]st
 	// new Allow, old AllowWithSubdirs, ancestor match -> same as ^^
 	// new AllowWithDir, old Allow -> replace always XXX
 	// new AllowWithDir, old AllowWithDir, exact match -> replace if different
-	// new AllowWithDir, old AllowWithSubdir, exact match -> same as ^^
+	// new AllowWithDir, old AllowWithSubdirs, exact match -> same as ^^
 	// new AllowWithDir, old AllowWithDir, parent match -> insert always XXX
-	// new AllowWithDir, old AllowWithSubdir, ancestor match -> insert if different
-	// new AllowWithSubdir, old Allow -> replace always XXX
-	// new AllowWithSubdir, old AllowWithDir, exact match -> replace always XXX
-	// new AllowWithSubdir, old AllowWithSubdir, exact match -> replace if different
-	// new AllowWithSubdir, old AllowWithDir, parent match -> insert always XXX
-	// new AllowWithSubdir, old AllowWithSubdir, ancestor match -> insert if different
+	// new AllowWithDir, old AllowWithSubdirs, ancestor match -> insert if different
+	// new AllowWithSubdirs, old Allow -> replace always XXX
+	// new AllowWithSubdirs, old AllowWithDir, exact match -> replace always XXX
+	// new AllowWithSubdirs, old AllowWithSubdirs, exact match -> replace if different
+	// new AllowWithSubdirs, old AllowWithDir, parent match -> insert always XXX
+	// new AllowWithSubdirs, old AllowWithSubdirs, ancestor match -> insert if different
 
 	// in summary:
 	// do nothing if decision matches and _not_ one of:
 	//  1. new AllowWithDir, old Allow
 	//  2. new AllowWithDir, old AllowWithDir, parent match
-	//  3. new AllowWithSubdir, old _not_ AllowWithSubdir
+	//  3. new AllowWithSubdirs, old _not_ AllowWithSubdir
 	// otherwise:
 	// remove any existing exact match (no-op if there is none)
 	// insert the path with the decision in the correct map
 
 	if (err == nil) && (alreadyAllowed == allow) {
 		// already in db and decision matches
-		if !((extras[extrasAllowWithDir] == "yes" && (&which == &labelEntries.Allow || (&which == &labelEntries.AllowWithDir && matchingPath != path))) || (extras[extrasAllowWithSubdirs] == "yes" && &which != &labelEntries.AllowWithSubdirs)) {
+		if !((((allow && extras[extrasAllowWithDir] == "yes") || (!allow && extras[extrasDenyWithDir] == "yes")) && (&which == &labelEntries.Allow || (&which == &labelEntries.AllowWithDir && matchingPath != path))) || (((allow && extras[extrasAllowWithSubdirs] == "yes") || (!allow && extras[extrasDenyWithSubdirs] == "yes")) && &which != &labelEntries.AllowWithSubdirs)) {
 			// don't need to do anything
 			return nil
 		}

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -15,17 +15,6 @@ import (
 var ErrNoSavedDecision = errors.New("no saved prompt decision")
 var ErrMultipleDecisions = errors.New("multiple prompt decisions for the same path")
 
-type userDB struct {
-	PerLabelDB map[string]*labelDB `json:"per-label-db"`
-}
-
-type labelDB struct {
-	Allow            map[string]bool `json:"allow"`
-	AllowWithDir     map[string]bool `json:"allow-with-dir"`
-	AllowWithSubdirs map[string]bool `json:"allow-with-subdir"`
-	// XXX: Always check with the following priority: Allow, then AllowWithDir, then AllowWithSubdirs
-}
-
 const (
 	// must match the specification for extra information map returned by the prompt
 	extrasAlwaysPrompt     = "always-prompt"
@@ -37,7 +26,18 @@ const (
 	extrasDenyExtraPerms   = "deny-extra-permissions"
 )
 
+type labelDB struct {
+	Allow            map[string]bool `json:"allow"`
+	AllowWithDir     map[string]bool `json:"allow-with-dir"`
+	AllowWithSubdirs map[string]bool `json:"allow-with-subdir"`
+	// XXX: Always check with the following priority: Allow, then AllowWithDir, then AllowWithSubdirs
+}
+
 // TODO: use Permission (interface{}) in place of bool to store particular permissions
+
+type userDB struct {
+	PerLabelDB map[string]*labelDB `json:"per-label-db"`
+}
 
 // TODO: make this an interface
 type PromptsDB struct {

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -191,7 +191,7 @@ func (pd *PromptsDB) Set(req *notifier.Request, allow bool, extras map[string]st
 
 	if (err == nil) && (alreadyAllowed == allow) {
 		// already in db and decision matches
-		if !((extras["allow-directory"] == "yes" && (which == "allow" || (which == "allow-with-dir" && matchingPath != path))) || (extras["allow-subdirectories"] == "yes" && which != "allow-with-subdirs")) {
+		if !((extras["allow-directory"] == "yes" && (which == "allow" || (which == "allow-with-dir" && matchingPath != path))) || (extras["allow-subdirectories"] == "yes" && which != "allow-with-subdir")) {
 			// don't need to do anything
 			return nil
 		}

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -38,10 +38,12 @@ func (s *storageSuite) TestSimple(c *C) {
 
 	allow := true
 	extra := map[string]string{}
+	extra["allow-subdirectories"] = "yes"
+	extra["deny-subdirectories"] = "yes"
 	err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 
-	paths := st.PathsForUidAndLabel(1000, "snap.lxd.lxd")
+	paths := st.MapsForUidAndLabel(1000, "snap.lxd.lxd").AllowWithSubdirs
 	c.Check(paths, HasLen, 1)
 
 	allowed, err = st.Get(req)
@@ -53,7 +55,7 @@ func (s *storageSuite) TestSimple(c *C) {
 	err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path is not added
-	paths = st.PathsForUidAndLabel(1000, "snap.lxd.lxd")
+	paths = st.MapsForUidAndLabel(1000, "snap.lxd.lxd").AllowWithSubdirs
 	c.Check(paths, HasLen, 1)
 
 	// and more nested path is still allowed
@@ -77,6 +79,8 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 
 	allow := true
 	extra := map[string]string{}
+	extra["allow-subdirectories"] = "yes"
+	extra["deny-subdirectories"] = "yes"
 	err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 
@@ -85,7 +89,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	err = st.Set(req, !allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path was added
-	paths := st.PathsForUidAndLabel(1000, "snap.lxd.lxd")
+	paths := st.MapsForUidAndLabel(1000, "snap.lxd.lxd").AllowWithSubdirs
 	c.Check(paths, HasLen, 2)
 
 	// and check more nested path is not allowed
@@ -107,7 +111,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	err = st.Set(req, !allow, extra)
 	c.Assert(err, IsNil)
 	// original assignment was overridden
-	paths = st.PathsForUidAndLabel(1000, "snap.lxd.lxd")
+	paths = st.MapsForUidAndLabel(1000, "snap.lxd.lxd").AllowWithSubdirs
 	c.Check(paths, HasLen, 2)
 	// TODO: in the future, possibly this should be 1, if we decide to remove
 	// subdirectories with the same access from the database when an ancestor
@@ -118,7 +122,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path was added
-	paths = st.PathsForUidAndLabel(1000, "snap.lxd.lxd")
+	paths = st.MapsForUidAndLabel(1000, "snap.lxd.lxd").AllowWithSubdirs
 	c.Check(paths, HasLen, 2)
 
 	// and check more nested path is allowed

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -29,7 +29,7 @@ func (s *storageSuite) TestSimple(c *C) {
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
 		SubjectUid: 1000,
-		Path:       "/home/test/foo",
+		Path:       "/home/test/foo/",
 	}
 
 	allowed, err := st.Get(req)
@@ -55,7 +55,6 @@ func (s *storageSuite) TestSimple(c *C) {
 	err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path is not added
-	paths = st.MapsForUidAndLabel(1000, "snap.lxd.lxd").AllowWithSubdirs
 	c.Check(paths, HasLen, 1)
 
 	// and more nested path is still allowed
@@ -70,7 +69,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
 		SubjectUid: 1000,
-		Path:       "/home/test/foo",
+		Path:       "/home/test/foo/",
 	}
 
 	allowed, err := st.Get(req)
@@ -85,7 +84,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	c.Assert(err, IsNil)
 
 	// set a more nested path to not allow
-	req.Path = "/home/test/foo/bar"
+	req.Path = "/home/test/foo/bar/"
 	err = st.Set(req, !allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path was added
@@ -102,7 +101,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(allowed, Equals, false)
 	// but original path is still allowed
-	req.Path = "/home/test/foo"
+	req.Path = "/home/test/foo/"
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
 	c.Check(allowed, Equals, true)
@@ -111,18 +110,16 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	err = st.Set(req, !allow, extra)
 	c.Assert(err, IsNil)
 	// original assignment was overridden
-	paths = st.MapsForUidAndLabel(1000, "snap.lxd.lxd").AllowWithSubdirs
 	c.Check(paths, HasLen, 2)
 	// TODO: in the future, possibly this should be 1, if we decide to remove
 	// subdirectories with the same access from the database when an ancestor
 	// directory with the same access is added
 
 	// set a more nested path to allow
-	req.Path = "/home/test/foo/bar"
+	req.Path = "/home/test/foo/bar/"
 	err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path was added
-	paths = st.MapsForUidAndLabel(1000, "snap.lxd.lxd").AllowWithSubdirs
 	c.Check(paths, HasLen, 2)
 
 	// and check more nested path is allowed
@@ -135,7 +132,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(allowed, Equals, true)
 	// but original path is still not allowed
-	req.Path = "/home/test/foo"
+	req.Path = "/home/test/foo/"
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
 	c.Check(allowed, Equals, false)


### PR DESCRIPTION
This adds handling for the "allow-directory" and "allow-subdirectories" options, and treats calls to `Set()` without either as allowing access to the given file (or directory) only.

When attempting to match a path to an existing decision, first search for a direct match in the Allow, AllowWithDir, or AllowWithSubdirs maps. Then, search for a direct match for the parent of the path in the AllowWithDir and AllowWithSubdirs maps. Lastly, search for a match to any ancestor of the path in the AllowWithSubdirs map.

The `Set()` function should never be able to store the same path in multiple maps.  However, if this does occur, then if a search for a path results in matches within multiple maps at the same time (that is, both match exact path, both match parent, or both match same ancestor), an error will be thrown.

Notably, this change now treats file-only permissions on directories as only allowing access to the directory file itself, not any of the files contained in the directory.  My interpretation is that this permits listing the contents of the directory but not accessing any of the listed files.

This is a first draft of this feature, and there remains work to be done to fix the existing unit tests as well as dramatically expand them to cover the many scenarios which can occur when searching for or overwriting previous decisions.