### PR TITLE
prompting: fixed typos to satisfy `./run-checks`

### DIFF
--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -64,6 +64,4 @@ func doExperimentalApparmorPromptProfileRegeneration(c RunTransaction, opts *fsO
 		// profile generate may take some time
 		return fmt.Errorf("%s is taking too long", regenerateProfilesChg.Kind())
 	}
-
-	return nil
 }

--- a/prompting/apparmor/ntype.go
+++ b/prompting/apparmor/ntype.go
@@ -12,7 +12,7 @@ const (
 	Response NotificationType = iota
 	// Cancel corresponds to APPARMOR_NOTIF_CANCEL.
 	Cancel
-	// Interrupt corresponds to APPARMOR_NOTIF_INTERUPT.
+	// Interrupt corresponds to APPARMOR_NOTIF_INTERRUPT.
 	Interrupt
 	// Alive corresponds to APPARMOR_NOTIF_ALIVE.
 	Alive

--- a/tests/main/prompting-dbus/task.yaml
+++ b/tests/main/prompting-dbus/task.yaml
@@ -44,7 +44,7 @@ prepare: |
     # TODO: build/install the snapcraft snap here to get the vendored userland
     #
     # Build the custom userspace version that supports prompting from
-    # JJs branch (TOOD: keep in sync with what the snapd snap uses)
+    # JJs branch (TODO: keep in sync with what the snapd snap uses)
     if [ "$AA_SOURCE" = git ]; then
         pushd /tmp
         apt build-dep -y apparmor


### PR DESCRIPTION
Fixes for a few small typos (and one unreachable return) to satisfy `./run-checks`.

I thought there was already a fix for the `INTERRUPT` typo in `prompting/apparmor/ntype.go`... I wonder where it went.
