### PR TITLE
prompting/storage: added per-permission decision handling

### DIFF
--- a/cmd/snapd-aa-prompt-listener/main.go
+++ b/cmd/snapd-aa-prompt-listener/main.go
@@ -193,7 +193,7 @@ func (p *PromptNotifierDbus) handleReq(req *notifier.Request) {
 
 	obj := p.conn.Object(agent.uniqeName, agent.path)
 	var resAllowed bool
-	var resExtra map[string]string
+	var resExtra map[storage.ExtrasKey]string
 	if err := obj.Call("io.snapcraft.PromptAgent.Prompt", 0, req.Path, info).Store(&resAllowed, &resExtra); err != nil {
 		logger.Noticef("cannot call prompt agent for %v: %v", uid, err)
 		return

--- a/cmd/snapd-aa-prompt-listener/main.go
+++ b/cmd/snapd-aa-prompt-listener/main.go
@@ -199,7 +199,7 @@ func (p *PromptNotifierDbus) handleReq(req *notifier.Request) {
 		return
 	}
 	logger.Debugf("got result: %v (%v)", resAllowed, resExtra)
-	if err := p.decisions.Set(req, resAllowed, resExtra); err != nil {
+	if _, err := p.decisions.Set(req, resAllowed, resExtra); err != nil {
 		logger.Noticef("cannot store prompt decision: %v", err)
 	}
 	req.YesNo <- resAllowed

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -278,6 +278,9 @@ func FindChildrenInMap(path string, allowMap map[string]bool) map[string]bool {
 func FindDescendantsInMap(path string, allowMap map[string]bool) map[string]bool {
 	matches := make(map[string]bool)
 	for pathEntry, decision := range allowMap {
+		if pathEntry == path {
+			continue // do not include exact matches, only descendants
+		}
 		p := pathEntry
 		for len(p) > len(path) {
 			p = filepath.Dir(p)

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -217,7 +217,7 @@ func WhichPermissions(req *notifier.Request, allow bool, extras map[ExtrasKey]st
 	perms := parseRequestPermissions(req)
 	if extraAllowPerms := extras[ExtrasAllowExtraPerms]; allow && extraAllowPerms != "" {
 		perms = appendUnique(perms, strings.Split(extraAllowPerms, ","))
-	} else if extraDenyPerms := extras[ExtrasDenyExtraPerms]; extraDenyPerms != "" {
+	} else if extraDenyPerms := extras[ExtrasDenyExtraPerms]; !allow && extraDenyPerms != "" {
 		perms = appendUnique(perms, strings.Split(extraDenyPerms, ","))
 	}
 	return perms

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -261,7 +261,8 @@ func newDecisionImpliedByPreviousDecision(permissionEntries *permissionDB, which
 
 // Returns a map of entries in allowMap which are children of the path, along
 // with the corresponding stored decision
-func findChildrenInMap(path string, allowMap map[string]bool) map[string]bool {
+// TODO: unexport
+func FindChildrenInMap(path string, allowMap map[string]bool) map[string]bool {
 	matches := make(map[string]bool)
 	for p, decision := range allowMap {
 		if filepath.Dir(p) == path {
@@ -273,14 +274,16 @@ func findChildrenInMap(path string, allowMap map[string]bool) map[string]bool {
 
 // Returns a map of entries in allowMap which are descendants of the path, along
 // with the corresponding stored decision
-func findDescendantsInMap(path string, allowMap map[string]bool) map[string]bool {
+// TODO: unexport
+func FindDescendantsInMap(path string, allowMap map[string]bool) map[string]bool {
 	matches := make(map[string]bool)
-	for p, decision := range allowMap {
+	for pathEntry, decision := range allowMap {
+		p := pathEntry
 		for len(p) > len(path) {
 			p = filepath.Dir(p)
 		}
 		if p == path {
-			matches[p] = decision
+			matches[pathEntry] = decision
 		}
 	}
 	return matches
@@ -324,7 +327,7 @@ func insertAndPrune(permissionEntries *permissionDB, which string, path string, 
 	case jsonAllowWithDir:
 		// delete direct match from other maps -- done above
 		// delete direct children from Allow map
-		toDeleteAllow := findChildrenInMap(path, permissionEntries.Allow)
+		toDeleteAllow := FindChildrenInMap(path, permissionEntries.Allow)
 		for p, decision := range toDeleteAllow {
 			delete(permissionEntries.Allow, p)
 			deleted.Allow[p] = decision
@@ -335,17 +338,17 @@ func insertAndPrune(permissionEntries *permissionDB, which string, path string, 
 	case jsonAllowWithSubdirs:
 		// delete direct match from other maps -- done above
 		// delete descendants from all other maps
-		toDeleteAllow := findDescendantsInMap(path, permissionEntries.Allow)
+		toDeleteAllow := FindDescendantsInMap(path, permissionEntries.Allow)
 		for p, decision := range toDeleteAllow {
 			delete(permissionEntries.Allow, p)
 			deleted.Allow[p] = decision
 		}
-		toDeleteAllowWithDir := findDescendantsInMap(path, permissionEntries.AllowWithDir)
+		toDeleteAllowWithDir := FindDescendantsInMap(path, permissionEntries.AllowWithDir)
 		for p, decision := range toDeleteAllowWithDir {
 			delete(permissionEntries.AllowWithDir, p)
 			deleted.AllowWithDir[p] = decision
 		}
-		toDeleteAllowWithSubdirs := findDescendantsInMap(path, permissionEntries.AllowWithSubdirs)
+		toDeleteAllowWithSubdirs := FindDescendantsInMap(path, permissionEntries.AllowWithSubdirs)
 		for p, decision := range toDeleteAllowWithSubdirs {
 			delete(permissionEntries.AllowWithSubdirs, p)
 			deleted.AllowWithSubdirs[p] = decision

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/snapcore/snapd/prompting/notifier"
 )
 
+var ErrNoPermissions = errors.New("request has no permissions set")
 var ErrNoSavedDecision = errors.New("no saved prompt decision")
 var ErrMultipleDecisions = errors.New("multiple prompt decisions for the same path")
 
@@ -289,6 +290,9 @@ func (pd *PromptsDB) Set(req *notifier.Request, allow bool, extras map[string]st
 func (pd *PromptsDB) Get(req *notifier.Request) (bool, error) {
 	allAllow := true
 	permissions := parseRequestPermissions(req)
+	if len(permissions) == 0 {
+		return false, ErrNoPermissions
+	}
 	for _, permission := range permissions {
 		permissionEntries := pd.MapsForUidAndLabelAndPermission(req.SubjectUid, req.Label, permission)
 		allow, err, _, _ := findPathInPermissionDB(permissionEntries, req.Path)
@@ -297,6 +301,6 @@ func (pd *PromptsDB) Get(req *notifier.Request) (bool, error) {
 			return allow, err
 		}
 	}
-	logger.Noticef("found promptDB decision %v for %v (uid %v)", allow, req.Path, req.SubjectUid)
+	logger.Noticef("found promptDB decision %v for %v (uid %v)", allAllow, req.Path, req.SubjectUid)
 	return allAllow, nil
 }

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -193,12 +193,25 @@ func parseRequestPermissions(req *notifier.Request) []string {
 	return strings.Split(req.Permission.(apparmor.FilePermission).String(), "|")
 }
 
+func appendUnique(list []string, other []string) []string {
+	combinedList := append(list, other...)
+	uniqueList := make([]string, 0, len(combinedList))
+	set := make(map[string]bool)
+	for _, item := range combinedList {
+		if _, exists := set[item]; !exists {
+			set[item] = true
+			uniqueList = append(uniqueList, item)
+		}
+	}
+	return uniqueList
+}
+
 func WhichPermissions(req *notifier.Request, allow bool, extras map[string]string) []string {
 	perms := parseRequestPermissions(req)
 	if extraAllow := extras[extrasAllowExtraPerms]; allow && extraAllow != "" {
-		perms = append(perms, strings.Split(extraAllow, ",")...)
+		perms = appendUnique(perms, strings.Split(extraAllow, ","))
 	} else if extraDeny := extras[extrasDenyExtraPerms]; extraDeny != "" {
-		perms = append(perms, strings.Split(extraDeny, ",")...)
+		perms = appendUnique(perms, strings.Split(extraDeny, ","))
 	}
 	return perms
 }

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -1326,23 +1326,23 @@ func (s *storageSuite) TestPermissionsComplex(c *C) {
 	_, err := st.Set(req, allow, extras)
 	c.Assert(err, Equals, nil)
 	/*
-	c.Assert(len(deleted), Equals, 3)
-	emptyMap := make(map[string]bool)
-	emptyDeleted := storage.permissionDB{
-		Allow: make(map[string]bool),
-		AllowWithDir: make(map[string]bool),
-		AllowWithSubdirs: make(map[string]bool),
-	}
-	c.Assert(reflect.DeepEqual(*deleted["read"], emptyDeleted), Equals, true, Commentf(`deleted["read"] should be empty: %+v`, deleted["read"]))
-	c.Assert(reflect.DeepEqual(deleted["read"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
-	c.Assert(reflect.DeepEqual(deleted["read"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
-	c.Assert(reflect.DeepEqual(deleted["read"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
-	c.Assert(reflect.DeepEqual(deleted["write"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
-	c.Assert(reflect.DeepEqual(deleted["write"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
-	c.Assert(reflect.DeepEqual(deleted["write"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
-	c.Assert(reflect.DeepEqual(deleted["execute"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
-	c.Assert(reflect.DeepEqual(deleted["execute"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
-	c.Assert(reflect.DeepEqual(deleted["execute"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
+		c.Assert(len(deleted), Equals, 3)
+		emptyMap := make(map[string]bool)
+		emptyDeleted := storage.permissionDB{
+			Allow: make(map[string]bool),
+			AllowWithDir: make(map[string]bool),
+			AllowWithSubdirs: make(map[string]bool),
+		}
+		c.Assert(reflect.DeepEqual(*deleted["read"], emptyDeleted), Equals, true, Commentf(`deleted["read"] should be empty: %+v`, deleted["read"]))
+		c.Assert(reflect.DeepEqual(deleted["read"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
+		c.Assert(reflect.DeepEqual(deleted["read"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
+		c.Assert(reflect.DeepEqual(deleted["read"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
+		c.Assert(reflect.DeepEqual(deleted["write"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
+		c.Assert(reflect.DeepEqual(deleted["write"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
+		c.Assert(reflect.DeepEqual(deleted["write"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
+		c.Assert(reflect.DeepEqual(deleted["execute"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
+		c.Assert(reflect.DeepEqual(deleted["execute"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
+		c.Assert(reflect.DeepEqual(deleted["execute"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
 	*/
 
 	allowed, err := st.Get(req)
@@ -1365,6 +1365,7 @@ func (s *storageSuite) TestPermissionsComplex(c *C) {
 	extras[storage.ExtrasDenyExtraPerms] = "create"
 	extras[storage.ExtrasDenyWithDir] = "yes"
 	_, err = st.Set(req, allow, extras)
+	c.Assert(err, Equals, nil)
 
 	allowed, err = st.Get(req)
 	c.Assert(err, Equals, nil)

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -1325,25 +1325,8 @@ func (s *storageSuite) TestPermissionsComplex(c *C) {
 	extras[storage.ExtrasAllowExtraPerms] = "write,execute"
 	_, err := st.Set(req, allow, extras)
 	c.Assert(err, Equals, nil)
-	/*
-		c.Assert(len(deleted), Equals, 3)
-		emptyMap := make(map[string]bool)
-		emptyDeleted := storage.permissionDB{
-			Allow: make(map[string]bool),
-			AllowWithDir: make(map[string]bool),
-			AllowWithSubdirs: make(map[string]bool),
-		}
-		c.Assert(reflect.DeepEqual(*deleted["read"], emptyDeleted), Equals, true, Commentf(`deleted["read"] should be empty: %+v`, deleted["read"]))
-		c.Assert(reflect.DeepEqual(deleted["read"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
-		c.Assert(reflect.DeepEqual(deleted["read"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
-		c.Assert(reflect.DeepEqual(deleted["read"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
-		c.Assert(reflect.DeepEqual(deleted["write"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
-		c.Assert(reflect.DeepEqual(deleted["write"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
-		c.Assert(reflect.DeepEqual(deleted["write"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
-		c.Assert(reflect.DeepEqual(deleted["execute"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
-		c.Assert(reflect.DeepEqual(deleted["execute"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
-		c.Assert(reflect.DeepEqual(deleted["execute"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
-	*/
+
+	// TODO: add checks that deleted decisions returned by Set() are correct
 
 	allowed, err := st.Get(req)
 	c.Assert(err, Equals, nil)

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -1185,6 +1185,12 @@ func (s *storageSuite) TestFindChildrenInMap(c *C) {
 			"/home/test/foo",
 			map[string]bool{"/home/test/foo/file.txt": true},
 		},
+		{
+			// don't match exact path, only children
+			map[string]bool{"/home/test": true, "/home/test/foo": false, "/home/test/foo/file.txt": true, "/home/test/bar": false},
+			"/home/test",
+			map[string]bool{"/home/test/foo": false, "/home/test/bar": false},
+		},
 	}
 	for i, testCase := range cases {
 		actualMatches := storage.FindChildrenInMap(testCase.path, testCase.origMap)
@@ -1212,6 +1218,12 @@ func (s *storageSuite) TestFindDescendantsInMap(c *C) {
 			map[string]bool{"/home/test": true, "/home/test/foo/file.txt": true, "/home/test/bar/baz.txt": false},
 			"/home/test/foo",
 			map[string]bool{"/home/test/foo/file.txt": true},
+		},
+		{
+			// don't match exact path, only descendants
+			map[string]bool{"/home/test": true, "/home/test/foo/file.txt": true, "/home/test/bar/baz.txt": false},
+			"/home/test",
+			map[string]bool{"/home/test/foo/file.txt": true, "/home/test/bar/baz.txt": false},
 		},
 	}
 	for i, testCase := range cases {

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -43,7 +43,7 @@ func (s *storageSuite) TestSimple(c *C) {
 	extra := map[string]string{}
 	extra["allow-subdirectories"] = "yes"
 	extra["deny-subdirectories"] = "yes"
-	err = st.Set(req, allow, extra)
+	_, err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 
 	paths := st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "read").AllowWithSubdirs
@@ -55,7 +55,7 @@ func (s *storageSuite) TestSimple(c *C) {
 
 	// set a more nested path
 	req.Path = "/home/test/foo/bar"
-	err = st.Set(req, allow, extra)
+	_, err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path is not added
 	c.Check(paths, HasLen, 1)
@@ -84,12 +84,12 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	extra := map[string]string{}
 	extra["allow-subdirectories"] = "yes"
 	extra["deny-subdirectories"] = "yes"
-	err = st.Set(req, allow, extra)
+	_, err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 
 	// set a more nested path to not allow
 	req.Path = "/home/test/foo/bar/"
-	err = st.Set(req, !allow, extra)
+	_, err = st.Set(req, !allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path was added
 	paths := st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "read").AllowWithSubdirs
@@ -111,7 +111,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	c.Check(allowed, Equals, true)
 
 	// set original path to not allow
-	err = st.Set(req, !allow, extra)
+	_, err = st.Set(req, !allow, extra)
 	c.Assert(err, IsNil)
 	// original assignment was overridden
 	c.Check(paths, HasLen, 2)
@@ -121,7 +121,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 
 	// set a more nested path to allow
 	req.Path = "/home/test/foo/bar/"
-	err = st.Set(req, allow, extra)
+	_, err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path was added
 	c.Check(paths, HasLen, 2)
@@ -1003,7 +1003,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 		permissionEntries.AllowWithDir = cloneAllowMap(testCase.initialAllowWithDir)
 		permissionEntries.AllowWithSubdirs = cloneAllowMap(testCase.initialAllowWithSubdirs)
 		req.Path = testCase.path
-		result := st.Set(req, testCase.decision, testCase.extras)
+		_, result := st.Set(req, testCase.decision, testCase.extras)
 		c.Assert(reflect.DeepEqual(permissionEntries.Allow, testCase.finalAllow), Equals, true, Commentf("\nTest case %d:\n%+v\nAllow does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
 		c.Assert(reflect.DeepEqual(permissionEntries.AllowWithDir, testCase.finalAllowWithDir), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithDir does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
 		c.Assert(reflect.DeepEqual(permissionEntries.AllowWithSubdirs, testCase.finalAllowWithSubdirs), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithSubdirs does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
@@ -1028,7 +1028,7 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 	extra := map[string]string{}
 	extra["allow-subdirectories"] = "yes"
 	extra["deny-subdirectories"] = "yes"
-	err = st.Set(req, allow, extra)
+	_, err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 
 	allowed, err = st.Get(req)
@@ -1043,7 +1043,7 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 
 	// set that permission to false with the same path
 	allow = false
-	err = st.Set(req, allow, extra)
+	_, err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 
 	allowed, err = st.Get(req)
@@ -1061,7 +1061,7 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 	req.Path = "/home/test/foo/bar/"
 	allow = false
 	extra["deny-extra-permissions"] = "read,write"
-	err = st.Set(req, allow, extra)
+	_, err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 
 	allowed, err = st.Get(req)
@@ -1143,7 +1143,7 @@ func (s *storageSuite) TestLoadSave(c *C) {
 		Permission: apparmor.MayReadPermission,
 	}
 	allow := true
-	err := st.Set(req, allow, nil)
+	_, err := st.Set(req, allow, nil)
 	c.Assert(err, IsNil)
 
 	// st2 will read DB from the previous storage

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -1099,14 +1099,14 @@ func (s *storageSuite) TestWhichPermissions(c *C) {
 	allow := true
 	extras := make(map[string]string)
 
-	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"read"}), Equals, true)
+	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"read"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 
 	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission
-	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"write", "read"}), Equals, true)
+	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"write", "read"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 
 	req.Permission = apparmor.MayExecutePermission
 	extras["allow-extra-permissions"] = "read,write"
-	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"execute", "read", "write"}), Equals, true)
+	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"execute", "read", "write"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 
 	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission
 	extras["allow-extra-permissions"] = "read,write,execute"

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -37,7 +37,7 @@ func (s *storageSuite) TestSimple(c *C) {
 
 	allowed, err := st.Get(req)
 	c.Assert(err, Equals, storage.ErrNoSavedDecision)
-	c.Check(allowed, Equals, false)
+	c.Assert(allowed, Equals, false)
 
 	allow := true
 	extra := map[string]string{}
@@ -47,23 +47,23 @@ func (s *storageSuite) TestSimple(c *C) {
 	c.Assert(err, IsNil)
 
 	paths := st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "read").AllowWithSubdirs
-	c.Check(paths, HasLen, 1)
+	c.Assert(paths, HasLen, 1)
 
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, true)
+	c.Assert(allowed, Equals, true)
 
 	// set a more nested path
 	req.Path = "/home/test/foo/bar"
 	_, err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path is not added
-	c.Check(paths, HasLen, 1)
+	c.Assert(paths, HasLen, 1)
 
 	// and more nested path is still allowed
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, true)
+	c.Assert(allowed, Equals, true)
 }
 
 func (s *storageSuite) TestSubdirOverrides(c *C) {
@@ -78,7 +78,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 
 	allowed, err := st.Get(req)
 	c.Assert(err, Equals, storage.ErrNoSavedDecision)
-	c.Check(allowed, Equals, false)
+	c.Assert(allowed, Equals, false)
 
 	allow := true
 	extra := map[string]string{}
@@ -93,29 +93,29 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	c.Assert(err, IsNil)
 	// more nested path was added
 	paths := st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "read").AllowWithSubdirs
-	c.Check(paths, HasLen, 2)
+	c.Assert(paths, HasLen, 2)
 
 	// and check more nested path is not allowed
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, false)
+	c.Assert(allowed, Equals, false)
 	// and even more nested path is not allowed
 	req.Path = "/home/test/foo/bar/baz"
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, false)
+	c.Assert(allowed, Equals, false)
 	// but original path is still allowed
 	req.Path = "/home/test/foo/"
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, true)
+	c.Assert(allowed, Equals, true)
 
 	// set original path to not allow
 	_, err = st.Set(req, !allow, extra)
 	c.Assert(err, IsNil)
 	// original assignment was overridden, and older more specific decisions
 	// were removed
-	c.Check(paths, HasLen, 1)
+	c.Assert(paths, HasLen, 1)
 	// TODO: in the future, possibly this should be 1, if we decide to remove
 	// subdirectories with the same access from the database when an ancestor
 	// directory with the same access is added
@@ -125,22 +125,22 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	_, err = st.Set(req, allow, extra)
 	c.Assert(err, IsNil)
 	// more nested path was added
-	c.Check(paths, HasLen, 2)
+	c.Assert(paths, HasLen, 2)
 
 	// and check more nested path is allowed
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, true)
+	c.Assert(allowed, Equals, true)
 	// and even more nested path is also allowed
 	req.Path = "/home/test/foo/bar/baz"
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, true)
+	c.Assert(allowed, Equals, true)
 	// but original path is still not allowed
 	req.Path = "/home/test/foo/"
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, false)
+	c.Assert(allowed, Equals, false)
 }
 
 func cloneAllowMap(m map[string]bool) map[string]bool {
@@ -353,8 +353,8 @@ func (s *storageSuite) TestGetMatches(c *C) {
 		permissionEntries.AllowWithSubdirs = cloneAllowMap(testCase.allowWithSubdirs)
 		req.Path = testCase.path
 		allow, err := st.Get(req)
-		c.Assert(err, IsNil, Commentf("\nTest case %d:\n%+v\nError: %v", i, testCase, err))
-		c.Assert(allow, Equals, testCase.decision, Commentf("\nTest case %d:\n%+v\nGet() returned: %v", i, testCase, allow))
+		c.Check(err, IsNil, Commentf("\nTest case %d:\n%+v\nError: %v", i, testCase, err))
+		c.Check(allow, Equals, testCase.decision, Commentf("\nTest case %d:\n%+v\nGet() returned: %v", i, testCase, allow))
 	}
 }
 
@@ -448,7 +448,7 @@ func (s *storageSuite) TestGetErrors(c *C) {
 		permissionEntries.AllowWithSubdirs = cloneAllowMap(testCase.allowWithSubdirs)
 		req.Path = testCase.path
 		_, err := st.Get(req)
-		c.Assert(err, Equals, testCase.err, Commentf("\nTest case %d:\n%+v\nUnexpected Error: %v", i, testCase, err))
+		c.Check(err, Equals, testCase.err, Commentf("\nTest case %d:\n%+v\nUnexpected Error: %v", i, testCase, err))
 	}
 }
 
@@ -1008,9 +1008,9 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 		permissionEntries.AllowWithSubdirs = cloneAllowMap(testCase.initialAllowWithSubdirs)
 		req.Path = testCase.path
 		_, result := st.Set(req, testCase.decision, testCase.extras)
-		c.Assert(reflect.DeepEqual(permissionEntries.Allow, testCase.finalAllow), Equals, true, Commentf("\nTest case %d:\n%+v\nAllow does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
-		c.Assert(reflect.DeepEqual(permissionEntries.AllowWithDir, testCase.finalAllowWithDir), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithDir does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
-		c.Assert(reflect.DeepEqual(permissionEntries.AllowWithSubdirs, testCase.finalAllowWithSubdirs), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithSubdirs does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(reflect.DeepEqual(permissionEntries.Allow, testCase.finalAllow), Equals, true, Commentf("\nTest case %d:\n%+v\nAllow does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(reflect.DeepEqual(permissionEntries.AllowWithDir, testCase.finalAllowWithDir), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithDir does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(reflect.DeepEqual(permissionEntries.AllowWithSubdirs, testCase.finalAllowWithSubdirs), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithSubdirs does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
 	}
 }
 
@@ -1158,9 +1158,9 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 		permissionEntries.AllowWithSubdirs = cloneAllowMap(testCase.initialAllowWithSubdirs)
 		req.Path = testCase.path
 		_, result := st.Set(req, testCase.decision, testCase.extras)
-		c.Assert(reflect.DeepEqual(permissionEntries.Allow, testCase.finalAllow), Equals, true, Commentf("\nTest case %d:\n%+v\nAllow does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
-		c.Assert(reflect.DeepEqual(permissionEntries.AllowWithDir, testCase.finalAllowWithDir), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithDir does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
-		c.Assert(reflect.DeepEqual(permissionEntries.AllowWithSubdirs, testCase.finalAllowWithSubdirs), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithSubdirs does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(reflect.DeepEqual(permissionEntries.Allow, testCase.finalAllow), Equals, true, Commentf("\nTest case %d:\n%+v\nAllow does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(reflect.DeepEqual(permissionEntries.AllowWithDir, testCase.finalAllowWithDir), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithDir does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(reflect.DeepEqual(permissionEntries.AllowWithSubdirs, testCase.finalAllowWithSubdirs), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithSubdirs does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
 	}
 }
 
@@ -1194,7 +1194,7 @@ func (s *storageSuite) TestFindChildrenInMap(c *C) {
 	}
 	for i, testCase := range cases {
 		actualMatches := storage.FindChildrenInMap(testCase.path, testCase.origMap)
-		c.Assert(reflect.DeepEqual(testCase.matches, actualMatches), Equals, true, Commentf("\nTest case %d:\n%+v\nIncorrect matches found\nActual matches: %+v", i, testCase, actualMatches))
+		c.Check(reflect.DeepEqual(testCase.matches, actualMatches), Equals, true, Commentf("\nTest case %d:\n%+v\nIncorrect matches found\nActual matches: %+v", i, testCase, actualMatches))
 	}
 }
 
@@ -1228,7 +1228,7 @@ func (s *storageSuite) TestFindDescendantsInMap(c *C) {
 	}
 	for i, testCase := range cases {
 		actualMatches := storage.FindDescendantsInMap(testCase.path, testCase.origMap)
-		c.Assert(reflect.DeepEqual(testCase.matches, actualMatches), Equals, true, Commentf("\nTest case %d:\n%+v\nIncorrect matches found\nActual matches: %+v", i, testCase, actualMatches))
+		c.Check(reflect.DeepEqual(testCase.matches, actualMatches), Equals, true, Commentf("\nTest case %d:\n%+v\nIncorrect matches found\nActual matches: %+v", i, testCase, actualMatches))
 	}
 }
 
@@ -1244,7 +1244,7 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 
 	allowed, err := st.Get(req)
 	c.Assert(err, Equals, storage.ErrNoSavedDecision)
-	c.Check(allowed, Equals, false)
+	c.Assert(allowed, Equals, false)
 
 	allow := true
 	extra := map[string]string{}
@@ -1255,13 +1255,13 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 
 	allowed, err = st.Get(req)
 	c.Assert(err, Equals, nil)
-	c.Check(allowed, Equals, true)
+	c.Assert(allowed, Equals, true)
 
 	// check a different permission
 	req.Permission = apparmor.MayWritePermission
 	allowed, err = st.Get(req)
 	c.Assert(err, Equals, storage.ErrNoSavedDecision)
-	c.Check(allowed, Equals, false)
+	c.Assert(allowed, Equals, false)
 
 	// set that permission to false with the same path
 	allow = false
@@ -1270,13 +1270,13 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 
 	allowed, err = st.Get(req)
 	c.Assert(err, Equals, nil)
-	c.Check(allowed, Equals, false)
+	c.Assert(allowed, Equals, false)
 
 	// check that original permission is still allowed
 	req.Permission = apparmor.MayReadPermission
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, true)
+	c.Assert(allowed, Equals, true)
 
 	// set denial of subpath for multiple permissions
 	req.Permission = apparmor.MayExecutePermission
@@ -1288,26 +1288,167 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, false)
+	c.Assert(allowed, Equals, false)
 
 	// check that read permission is now false for subpath
 	req.Permission = apparmor.MayReadPermission
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, false)
+	c.Assert(allowed, Equals, false)
 	// but original path is still allowed
 	req.Path = "/home/test/foo/"
 	allowed, err = st.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, true)
+	c.Assert(allowed, Equals, true)
 
 	// check that there are 2 rules for read but the write rule was coalesced
 	paths := st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "read").AllowWithSubdirs
-	c.Check(paths, HasLen, 2)
+	c.Assert(paths, HasLen, 2)
 	paths = st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "write").AllowWithSubdirs
-	c.Check(paths, HasLen, 1)
+	c.Assert(paths, HasLen, 1)
 	paths = st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "execute").AllowWithSubdirs
-	c.Check(paths, HasLen, 1)
+	c.Assert(paths, HasLen, 1)
+}
+
+func (s *storageSuite) TestPermissionsComplex(c *C) {
+	st := storage.New()
+
+	req := &notifier.Request{
+		Label:      "snap.lxd.lxd",
+		SubjectUid: 1000,
+	}
+	extra := map[string]string{}
+
+	allow := true
+	req.Path = "/home/test/foo/script.sh"
+	req.Permission = apparmor.MayReadPermission
+	extra["allow-extra-permissions"] = "write,execute"
+	_, err := st.Set(req, allow, extra)
+	c.Assert(err, Equals, nil)
+	/*
+	c.Assert(len(deleted), Equals, 3)
+	emptyMap := make(map[string]bool)
+	emptyDeleted := storage.permissionDB{
+		Allow: make(map[string]bool),
+		AllowWithDir: make(map[string]bool),
+		AllowWithSubdirs: make(map[string]bool),
+	}
+	c.Assert(reflect.DeepEqual(*deleted["read"], emptyDeleted), Equals, true, Commentf(`deleted["read"] should be empty: %+v`, deleted["read"]))
+	c.Assert(reflect.DeepEqual(deleted["read"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
+	c.Assert(reflect.DeepEqual(deleted["read"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
+	c.Assert(reflect.DeepEqual(deleted["read"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
+	c.Assert(reflect.DeepEqual(deleted["write"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
+	c.Assert(reflect.DeepEqual(deleted["write"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
+	c.Assert(reflect.DeepEqual(deleted["write"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
+	c.Assert(reflect.DeepEqual(deleted["execute"].Allow, emptyMap), Equals, true, Commentf(`deleted["read"].Allow should be empty: %+v`, deleted["read"].Allow))
+	c.Assert(reflect.DeepEqual(deleted["execute"].AllowWithDir, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithDir should be empty: %+v`, deleted["read"].AllowWithDir))
+	c.Assert(reflect.DeepEqual(deleted["execute"].AllowWithSubdirs, emptyMap), Equals, true, Commentf(`deleted["read"].AllowWithSubdirs should be empty: %+v`, deleted["read"].AllowWithSubdirs))
+	*/
+
+	allowed, err := st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, true)
+
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission | apparmor.MayExecutePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, true)
+
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission | apparmor.MayExecutePermission | apparmor.MayAppendPermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, storage.ErrNoSavedDecision)
+	c.Assert(allowed, Equals, false)
+
+	allow = false
+	req.Path = "/home/test/foo/"
+	req.Permission = apparmor.MayWritePermission | apparmor.MayExecutePermission
+	extra["deny-extra-permissions"] = "create"
+	extra["deny-directory"] = "yes"
+	_, err = st.Set(req, allow, extra)
+
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, false)
+
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission | apparmor.MayExecutePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, storage.ErrNoSavedDecision)
+	c.Assert(allowed, Equals, false)
+
+	req.Path = "/home/test/foo/script.sh"
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, false)
+
+	req.Permission = apparmor.MayReadPermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, true)
+
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, false)
+
+	req.Permission = apparmor.MayReadPermission | apparmor.MayOpenPermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, storage.ErrNoSavedDecision)
+	c.Assert(allowed, Equals, false)
+
+	allow = true
+	req.Path = "/home/test/"
+	req.Permission = apparmor.MayWritePermission
+	extra["allow-extra-permissions"] = "read"
+	extra["allow-subdirectories"] = "yes"
+	_, err = st.Set(req, allow, extra)
+	c.Assert(err, Equals, nil)
+
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, true)
+
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, true)
+
+	req.Path = "/home/test/foo"
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, true)
+
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission | apparmor.MayExecutePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, false)
+
+	req.Path = "/home/test/foo/script.sh"
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, true)
+
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission | apparmor.MayExecutePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, false)
+
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission | apparmor.MayExecutePermission | apparmor.MayCreatePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, false)
+
+	req.Path = "/home/test/foo/bar/baz.txt"
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, true)
+
+	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission | apparmor.MayExecutePermission
+	allowed, err = st.Get(req)
+	c.Assert(err, Equals, storage.ErrNoSavedDecision)
+	c.Assert(allowed, Equals, false)
 }
 
 func (s *storageSuite) TestWhichPermissions(c *C) {
@@ -1372,5 +1513,5 @@ func (s *storageSuite) TestLoadSave(c *C) {
 	st2 := storage.New()
 	allowed, err := st2.Get(req)
 	c.Assert(err, IsNil)
-	c.Check(allowed, Equals, true)
+	c.Assert(allowed, Equals, true)
 }

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -1,7 +1,6 @@
 package storage_test
 
 import (
-	"reflect"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -1008,9 +1007,9 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 		permissionEntries.AllowWithSubdirs = cloneAllowMap(testCase.initialAllowWithSubdirs)
 		req.Path = testCase.path
 		_, result := st.Set(req, testCase.decision, testCase.extras)
-		c.Check(reflect.DeepEqual(permissionEntries.Allow, testCase.finalAllow), Equals, true, Commentf("\nTest case %d:\n%+v\nAllow does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
-		c.Check(reflect.DeepEqual(permissionEntries.AllowWithDir, testCase.finalAllowWithDir), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithDir does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
-		c.Check(reflect.DeepEqual(permissionEntries.AllowWithSubdirs, testCase.finalAllowWithSubdirs), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithSubdirs does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(permissionEntries.Allow, DeepEquals, testCase.finalAllow, Commentf("\nTest case %d:\n%+v\nAllow does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(permissionEntries.AllowWithDir, DeepEquals, testCase.finalAllowWithDir, Commentf("\nTest case %d:\n%+v\nAllowWithDir does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(permissionEntries.AllowWithSubdirs, DeepEquals, testCase.finalAllowWithSubdirs, Commentf("\nTest case %d:\n%+v\nAllowWithSubdirs does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
 	}
 }
 
@@ -1158,9 +1157,9 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 		permissionEntries.AllowWithSubdirs = cloneAllowMap(testCase.initialAllowWithSubdirs)
 		req.Path = testCase.path
 		_, result := st.Set(req, testCase.decision, testCase.extras)
-		c.Check(reflect.DeepEqual(permissionEntries.Allow, testCase.finalAllow), Equals, true, Commentf("\nTest case %d:\n%+v\nAllow does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
-		c.Check(reflect.DeepEqual(permissionEntries.AllowWithDir, testCase.finalAllowWithDir), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithDir does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
-		c.Check(reflect.DeepEqual(permissionEntries.AllowWithSubdirs, testCase.finalAllowWithSubdirs), Equals, true, Commentf("\nTest case %d:\n%+v\nAllowWithSubdirs does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(permissionEntries.Allow, DeepEquals, testCase.finalAllow, Commentf("\nTest case %d:\n%+v\nAllow does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(permissionEntries.AllowWithDir, DeepEquals, testCase.finalAllowWithDir, Commentf("\nTest case %d:\n%+v\nAllowWithDir does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
+		c.Check(permissionEntries.AllowWithSubdirs, DeepEquals, testCase.finalAllowWithSubdirs, Commentf("\nTest case %d:\n%+v\nAllowWithSubdirs does not match\nActual Allow: %+v\nActual AllowWithDir: %+v\nActualAllowWithSubdirs: %+v\nSet() returned: %v\n", i, testCase, permissionEntries.Allow, permissionEntries.AllowWithDir, permissionEntries.AllowWithSubdirs, result))
 	}
 }
 
@@ -1194,7 +1193,7 @@ func (s *storageSuite) TestFindChildrenInMap(c *C) {
 	}
 	for i, testCase := range cases {
 		actualMatches := storage.FindChildrenInMap(testCase.path, testCase.origMap)
-		c.Check(reflect.DeepEqual(testCase.matches, actualMatches), Equals, true, Commentf("\nTest case %d:\n%+v\nIncorrect matches found\nActual matches: %+v", i, testCase, actualMatches))
+		c.Check(testCase.matches, DeepEquals, actualMatches, Commentf("\nTest case %d:\n%+v\nIncorrect matches found\nActual matches: %+v", i, testCase, actualMatches))
 	}
 }
 
@@ -1228,7 +1227,7 @@ func (s *storageSuite) TestFindDescendantsInMap(c *C) {
 	}
 	for i, testCase := range cases {
 		actualMatches := storage.FindDescendantsInMap(testCase.path, testCase.origMap)
-		c.Check(reflect.DeepEqual(testCase.matches, actualMatches), Equals, true, Commentf("\nTest case %d:\n%+v\nIncorrect matches found\nActual matches: %+v", i, testCase, actualMatches))
+		c.Check(testCase.matches, DeepEquals, actualMatches, Commentf("\nTest case %d:\n%+v\nIncorrect matches found\nActual matches: %+v", i, testCase, actualMatches))
 	}
 }
 
@@ -1446,18 +1445,18 @@ func (s *storageSuite) TestWhichPermissions(c *C) {
 	allow := true
 	extras := make(map[storage.ExtrasKey]string)
 
-	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"read"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
+	c.Assert(storage.WhichPermissions(req, allow, extras), DeepEquals, []string{"read"}, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 
 	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission
-	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"write", "read"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
+	c.Assert(storage.WhichPermissions(req, allow, extras), DeepEquals, []string{"write", "read"}, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 
 	req.Permission = apparmor.MayExecutePermission
 	extras[storage.ExtrasAllowExtraPerms] = "read,write"
-	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"execute", "read", "write"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
+	c.Assert(storage.WhichPermissions(req, allow, extras), DeepEquals, []string{"execute", "read", "write"}, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 
 	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission
 	extras[storage.ExtrasAllowExtraPerms] = "read,write,execute"
-	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"write", "read", "execute"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
+	c.Assert(storage.WhichPermissions(req, allow, extras), DeepEquals, []string{"write", "read", "execute"}, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 }
 
 func (s *storageSuite) TestGetDoesNotCorruptPath(c *C) {

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -40,10 +40,10 @@ func (s *storageSuite) TestSimple(c *C) {
 	c.Assert(allowed, Equals, false)
 
 	allow := true
-	extra := map[string]string{}
-	extra["allow-subdirectories"] = "yes"
-	extra["deny-subdirectories"] = "yes"
-	_, err = st.Set(req, allow, extra)
+	extras := map[storage.ExtrasKey]string{}
+	extras[storage.ExtrasAllowWithSubdirs] = "yes"
+	extras[storage.ExtrasDenyWithSubdirs] = "yes"
+	_, err = st.Set(req, allow, extras)
 	c.Assert(err, IsNil)
 
 	paths := st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "read").AllowWithSubdirs
@@ -55,7 +55,7 @@ func (s *storageSuite) TestSimple(c *C) {
 
 	// set a more nested path
 	req.Path = "/home/test/foo/bar"
-	_, err = st.Set(req, allow, extra)
+	_, err = st.Set(req, allow, extras)
 	c.Assert(err, IsNil)
 	// more nested path is not added
 	c.Assert(paths, HasLen, 1)
@@ -81,15 +81,15 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	c.Assert(allowed, Equals, false)
 
 	allow := true
-	extra := map[string]string{}
-	extra["allow-subdirectories"] = "yes"
-	extra["deny-subdirectories"] = "yes"
-	_, err = st.Set(req, allow, extra)
+	extras := map[storage.ExtrasKey]string{}
+	extras[storage.ExtrasAllowWithSubdirs] = "yes"
+	extras[storage.ExtrasDenyWithSubdirs] = "yes"
+	_, err = st.Set(req, allow, extras)
 	c.Assert(err, IsNil)
 
 	// set a more nested path to not allow
 	req.Path = "/home/test/foo/bar/"
-	_, err = st.Set(req, !allow, extra)
+	_, err = st.Set(req, !allow, extras)
 	c.Assert(err, IsNil)
 	// more nested path was added
 	paths := st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "read").AllowWithSubdirs
@@ -111,7 +111,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	c.Assert(allowed, Equals, true)
 
 	// set original path to not allow
-	_, err = st.Set(req, !allow, extra)
+	_, err = st.Set(req, !allow, extras)
 	c.Assert(err, IsNil)
 	// original assignment was overridden, and older more specific decisions
 	// were removed
@@ -122,7 +122,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 
 	// set a more nested path to allow
 	req.Path = "/home/test/foo/bar/"
-	_, err = st.Set(req, allow, extra)
+	_, err = st.Set(req, allow, extras)
 	c.Assert(err, IsNil)
 	// more nested path was added
 	c.Assert(paths, HasLen, 2)
@@ -478,7 +478,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 		initialAllowWithSubdirs map[string]bool
 		path                    string
 		decision                bool
-		extras                  map[string]string
+		extras                  map[storage.ExtrasKey]string
 		finalAllow              map[string]bool
 		finalAllowWithDir       map[string]bool
 		finalAllowWithSubdirs   map[string]bool
@@ -489,7 +489,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo": true},
 			map[string]bool{},
 			map[string]bool{},
@@ -500,7 +500,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo",
 			false,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{},
 			map[string]bool{},
@@ -511,7 +511,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
 			map[string]bool{},
@@ -522,7 +522,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo",
 			false,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{},
 			map[string]bool{},
@@ -533,7 +533,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo": true},
 			map[string]bool{},
 			map[string]bool{},
@@ -544,7 +544,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": true},
 			"/home/test/foo",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
@@ -555,7 +555,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": true},
 			"/home/test/foo",
 			false,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{},
 			map[string]bool{},
@@ -566,7 +566,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": false},
 			"/home/test/foo",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo": true},
 			map[string]bool{},
 			map[string]bool{},
@@ -577,7 +577,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{},
 			map[string]bool{"/home/test": true},
 			map[string]bool{},
@@ -588,7 +588,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo",
 			false,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{"/home/test": true},
 			map[string]bool{},
@@ -599,7 +599,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/bar",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo/bar": true},
 			map[string]bool{"/home/test": true},
 			map[string]bool{},
@@ -610,7 +610,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test": true},
 			"/home/test/foo/bar",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test": true},
@@ -621,7 +621,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test": true},
 			"/home/test/foo/bar",
 			false,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo/bar": false},
 			map[string]bool{},
 			map[string]bool{"/home/test": true},
@@ -632,7 +632,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test": false},
 			"/home/test/foo/bar",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo/bar": true},
 			map[string]bool{},
 			map[string]bool{"/home/test": false},
@@ -643,7 +643,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": true},
 			"/home/test/bar",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/bar": true},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
@@ -654,7 +654,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": true},
 			"/home/test/bar",
 			false,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/bar": false},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
@@ -665,7 +665,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			true,
-			map[string]string{"allow-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
 			map[string]bool{},
@@ -676,7 +676,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{},
@@ -687,7 +687,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{},
@@ -698,7 +698,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			true,
-			map[string]string{"allow-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
 			map[string]bool{},
@@ -709,7 +709,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{},
@@ -720,7 +720,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": true},
 			"/home/test/foo/",
 			true,
-			map[string]string{"allow-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
@@ -731,7 +731,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": true},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{},
@@ -742,7 +742,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": false},
 			"/home/test/foo/",
 			true,
-			map[string]string{"allow-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
 			map[string]bool{},
@@ -753,7 +753,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": false},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
@@ -764,7 +764,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			true,
-			map[string]string{"allow-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test": true, "/home/test/foo": true},
 			map[string]bool{},
@@ -775,7 +775,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test": true, "/home/test/foo": false},
 			map[string]bool{},
@@ -786,7 +786,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test": true},
 			"/home/test/foo/bar/",
 			true,
-			map[string]string{"allow-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test": true},
@@ -797,7 +797,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test": true},
 			"/home/test/foo/bar/",
 			false,
-			map[string]string{"deny-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo/bar": false},
 			map[string]bool{"/home/test": true},
@@ -808,7 +808,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test": false},
 			"/home/test/foo/",
 			true,
-			map[string]string{"allow-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
 			map[string]bool{"/home/test": false},
@@ -819,7 +819,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			true,
-			map[string]string{"allow-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
@@ -830,7 +830,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
@@ -841,7 +841,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
@@ -852,7 +852,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			true,
-			map[string]string{"allow-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
@@ -863,7 +863,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
@@ -874,7 +874,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
@@ -885,7 +885,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
@@ -896,7 +896,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": true},
 			"/home/test/foo/",
 			true,
-			map[string]string{"allow-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
@@ -907,7 +907,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": true},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
@@ -918,7 +918,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			true,
-			map[string]string{"allow-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test": true},
 			map[string]bool{"/home/test/foo": true},
@@ -929,7 +929,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test": true},
 			map[string]bool{"/home/test/foo": false},
@@ -940,7 +940,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{},
 			"/home/test/foo/bar/",
 			true,
-			map[string]string{"allow-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test": true},
 			map[string]bool{"/home/test/foo/bar": true},
@@ -951,7 +951,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test": true},
 			"/home/test/foo/bar/",
 			true,
-			map[string]string{"allow-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test": true},
@@ -962,7 +962,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test": true},
 			"/home/test/foo/bar/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test": true, "/home/test/foo/bar": false},
@@ -973,7 +973,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test": false},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test": false},
@@ -984,7 +984,7 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 			map[string]bool{"/home/test/foo": true},
 			"/home/test/bar/",
 			true,
-			map[string]string{"allow-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true, "/home/test/bar": true},
@@ -1024,7 +1024,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 		initialAllowWithSubdirs map[string]bool
 		path                    string
 		decision                bool
-		extras                  map[string]string
+		extras                  map[storage.ExtrasKey]string
 		finalAllow              map[string]bool
 		finalAllowWithDir       map[string]bool
 		finalAllowWithSubdirs   map[string]bool
@@ -1035,7 +1035,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 			map[string]bool{},
 			"/home/test/foo",
 			false,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{},
 			map[string]bool{},
@@ -1046,7 +1046,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 			map[string]bool{},
 			"/home/test/foo",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": true},
 			map[string]bool{},
@@ -1057,7 +1057,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 			map[string]bool{"/home/test/foo": true},
 			"/home/test/foo",
 			false,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{},
 			map[string]bool{},
@@ -1068,7 +1068,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 			map[string]bool{"/home/test": true},
 			"/home/test/foo",
 			false,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo/bar.txt": true},
 			map[string]bool{"/home/test/foo": false},
 			map[string]bool{"/home/test": true},
@@ -1079,7 +1079,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 			map[string]bool{"/home/test": true},
 			"/home/test/foo",
 			true,
-			map[string]string{},
+			map[storage.ExtrasKey]string{},
 			map[string]bool{"/home/test/foo/bar.txt": true},
 			map[string]bool{},
 			map[string]bool{"/home/test": true},
@@ -1090,7 +1090,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 			map[string]bool{"/home/test/foo": true, "/home/test/foo/subdir": false},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithDir: "yes"},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false, "/home/test/foo/dir1": true, "/home/test/foo/dir2": false},
 			map[string]bool{"/home/test/foo/subdir": false},
@@ -1101,7 +1101,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 			map[string]bool{"/home/test/foo": true, "/home/test/foo/subdir": false},
 			"/home/test/",
 			true,
-			map[string]string{"allow-directory": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithDir: "yes"},
 			map[string]bool{"/home/test/foo/bar.txt": true, "/home/test/foo/baz.txt": false},
 			map[string]bool{"/home/test": true, "/home/test/foo/dir1": true, "/home/test/foo/dir2": false},
 			map[string]bool{"/home/test/foo": true, "/home/test/foo/subdir": false},
@@ -1112,7 +1112,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 			map[string]bool{"/home/test/foo": true, "/home/test/foo/subdir": false},
 			"/home/test/",
 			true,
-			map[string]string{"allow-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasAllowWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test": true},
@@ -1123,7 +1123,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 			map[string]bool{"/home/test/foo": true, "/home/test/foo/subdir": false},
 			"/home/test/foo/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{},
 			map[string]bool{},
 			map[string]bool{"/home/test/foo": false},
@@ -1134,7 +1134,7 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 			map[string]bool{"/home/test/foo": true, "/home/test/foo/subdir": false},
 			"/home/test/foo/dir1/",
 			false,
-			map[string]string{"deny-subdirectories": "yes"},
+			map[storage.ExtrasKey]string{storage.ExtrasDenyWithSubdirs: "yes"},
 			map[string]bool{"/home/test/foo/bar.txt": true, "/home/test/foo/baz.txt": false},
 			map[string]bool{"/home/test/foo/dir2": false},
 			map[string]bool{"/home/test/foo": true, "/home/test/foo/dir1": false, "/home/test/foo/subdir": false},
@@ -1247,10 +1247,10 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 	c.Assert(allowed, Equals, false)
 
 	allow := true
-	extra := map[string]string{}
-	extra["allow-subdirectories"] = "yes"
-	extra["deny-subdirectories"] = "yes"
-	_, err = st.Set(req, allow, extra)
+	extras := map[storage.ExtrasKey]string{}
+	extras[storage.ExtrasAllowWithSubdirs] = "yes"
+	extras[storage.ExtrasDenyWithSubdirs] = "yes"
+	_, err = st.Set(req, allow, extras)
 	c.Assert(err, IsNil)
 
 	allowed, err = st.Get(req)
@@ -1265,7 +1265,7 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 
 	// set that permission to false with the same path
 	allow = false
-	_, err = st.Set(req, allow, extra)
+	_, err = st.Set(req, allow, extras)
 	c.Assert(err, IsNil)
 
 	allowed, err = st.Get(req)
@@ -1282,8 +1282,8 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 	req.Permission = apparmor.MayExecutePermission
 	req.Path = "/home/test/foo/bar/"
 	allow = false
-	extra["deny-extra-permissions"] = "read,write"
-	_, err = st.Set(req, allow, extra)
+	extras[storage.ExtrasDenyExtraPerms] = "read,write"
+	_, err = st.Set(req, allow, extras)
 	c.Assert(err, IsNil)
 
 	allowed, err = st.Get(req)
@@ -1317,13 +1317,13 @@ func (s *storageSuite) TestPermissionsComplex(c *C) {
 		Label:      "snap.lxd.lxd",
 		SubjectUid: 1000,
 	}
-	extra := map[string]string{}
+	extras := map[storage.ExtrasKey]string{}
 
 	allow := true
 	req.Path = "/home/test/foo/script.sh"
 	req.Permission = apparmor.MayReadPermission
-	extra["allow-extra-permissions"] = "write,execute"
-	_, err := st.Set(req, allow, extra)
+	extras[storage.ExtrasAllowExtraPerms] = "write,execute"
+	_, err := st.Set(req, allow, extras)
 	c.Assert(err, Equals, nil)
 	/*
 	c.Assert(len(deleted), Equals, 3)
@@ -1362,9 +1362,9 @@ func (s *storageSuite) TestPermissionsComplex(c *C) {
 	allow = false
 	req.Path = "/home/test/foo/"
 	req.Permission = apparmor.MayWritePermission | apparmor.MayExecutePermission
-	extra["deny-extra-permissions"] = "create"
-	extra["deny-directory"] = "yes"
-	_, err = st.Set(req, allow, extra)
+	extras[storage.ExtrasDenyExtraPerms] = "create"
+	extras[storage.ExtrasDenyWithDir] = "yes"
+	_, err = st.Set(req, allow, extras)
 
 	allowed, err = st.Get(req)
 	c.Assert(err, Equals, nil)
@@ -1398,9 +1398,9 @@ func (s *storageSuite) TestPermissionsComplex(c *C) {
 	allow = true
 	req.Path = "/home/test/"
 	req.Permission = apparmor.MayWritePermission
-	extra["allow-extra-permissions"] = "read"
-	extra["allow-subdirectories"] = "yes"
-	_, err = st.Set(req, allow, extra)
+	extras[storage.ExtrasAllowExtraPerms] = "read"
+	extras[storage.ExtrasAllowWithSubdirs] = "yes"
+	_, err = st.Set(req, allow, extras)
 	c.Assert(err, Equals, nil)
 
 	allowed, err = st.Get(req)
@@ -1460,7 +1460,7 @@ func (s *storageSuite) TestWhichPermissions(c *C) {
 	}
 
 	allow := true
-	extras := make(map[string]string)
+	extras := make(map[storage.ExtrasKey]string)
 
 	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"read"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 
@@ -1468,11 +1468,11 @@ func (s *storageSuite) TestWhichPermissions(c *C) {
 	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"write", "read"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 
 	req.Permission = apparmor.MayExecutePermission
-	extras["allow-extra-permissions"] = "read,write"
+	extras[storage.ExtrasAllowExtraPerms] = "read,write"
 	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"execute", "read", "write"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 
 	req.Permission = apparmor.MayReadPermission | apparmor.MayWritePermission
-	extras["allow-extra-permissions"] = "read,write,execute"
+	extras[storage.ExtrasAllowExtraPerms] = "read,write,execute"
 	c.Assert(reflect.DeepEqual(storage.WhichPermissions(req, allow, extras), []string{"write", "read", "execute"}), Equals, true, Commentf("WhichPermissions output: %q", storage.WhichPermissions(req, allow, extras)))
 }
 


### PR DESCRIPTION
This change introduces handling to allow or deny particular file permissions on filepaths.  This is done by adding another map layer between label and paths: for each label, there is a map which maps from permission (`string`) to `*permissionDB`, where the original `Allow`, `AllowWithDir`, and `AllowWithSubdirs` maps still reside.

Thus, the allow maps for different permissions are fully independent. For example, one could set `/home/test/Documents` to allow read access with subdirectories, but write access only with directory (that is, entries directly in `/home/test/Documents/`).

At the moment, the requests passed into `Get()` and `Set()` contain a `Permission` field which is populated from type
`apparmor.FilePermission`, which is (for now) a bitflag.  These bitflags are converted into a `[]string` where each element is the string corresponding to the permission bit as defined in
`prompting/apparmor/permission.go`.

Since the `Get()` function only has a `notifier.Request` as input, the permission in question can be extracted from it according to the method described above.  For `Set()`, however, there is the additional `extras["{allow,deny}-extra-permissions"]` parameter to handle as well. For now, these permissions are expected to be comma-separated strings which again correspond to the permission bits as defined in `prompting/apparmor/permission.go`, and they are appended to those permissions extracted from the `Permission` field of the `notifier.Request`, and thus treated no differently.

It is assumed that only one permission bit should be set in the `Permission` field of the `notifier.Request`, but handling has been added to `Get()` in case multiple bits are set -- in this case, every permission must be allowed, else the `allow` field is returned as `false`.  `Set()` needs no additional special handling, as it is already assumed that there may be multiple permissions defined between the `Permissions` and `extras["{allow,deny}-extra-permissions"]`.

It is, however, assumed that the same allow/deny decision must be set to all the permissions passed into `Set()` (via the `req.Permissions` field or the `extras` parameter) at a time.  To allow some permissions for a path and deny others, `Set()` may be called multiple times with different values for the `allow` parameter.

Alternatively, a future approach might be to respect `extras["allow-extra-permissions"]` and
`extras["deny-extra-permissions"]` independently of the value of the `allow` parameter.  However, at the moment, the apparmor prompting spec indicates that the `"allow-*"` and `"deny-*"` keys may only be used when `allow = true` and `allow = false`, respectively.
