### PR TITLE
cmd/snapd-aa-prompt-ui: fix the "unknown operation" message in the prompt ui

### DIFF
--- a/cmd/snapd-aa-prompt-ui/snapd-aa-prompt-ui-gtk
+++ b/cmd/snapd-aa-prompt-ui/snapd-aa-prompt-ui-gtk
@@ -84,7 +84,7 @@ class Agent(dbus.service.Object):
         # XXX: spec says we get the snap/app from info
         app = info.get("label","no-label")
         icon = info.get("icon", "no-icon")
-        operation = info.get("operation", "unknown operation")
+        operation = info.get("permission", "unknown operation")
         dialog = PromptDialog(app, icon, path, operation)
         res = dialog.run()
         if res == PromptDialog.RESPONSE_ALLOW:


### PR DESCRIPTION
The dbus field is `"permission"`, rather than `"operation"`.

The value is the apparmor permission bitflag, rather than a human readable operation. Thus, the prompt UI must convert it to a string, and since the previous conversion is at `prompting/apparmor/permission.go` but the UI is written in python, the conversion cannot be imported directly and must be rewritten.