### PR TITLE
Apparmor prompting: store decisions by ID

### DIFF
--- a/cmd/snapd-aa-prompt-listener/main.go
+++ b/cmd/snapd-aa-prompt-listener/main.go
@@ -199,7 +199,7 @@ func (p *PromptNotifierDbus) handleReq(req *notifier.Request) {
 		return
 	}
 	logger.Debugf("got result: %v (%v)", resAllowed, resExtra)
-	if _, err := p.decisions.Set(req, resAllowed, resExtra); err != nil {
+	if _, _, _, err := p.decisions.Set(req, resAllowed, resExtra); err != nil {
 		logger.Noticef("cannot store prompt decision: %v", err)
 	}
 	req.YesNo <- resAllowed

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -254,15 +254,15 @@ func (pd *PromptsDB) PermissionsMapForUidAndSnapAndApp(uid uint32, snap string, 
 
 // TODO: unexport
 func (pd *PromptsDB) MapsForUidAndSnapAndAppAndPermission(uid uint32, snap string, app string, permission string) *permissionDB {
-	permissionMap := pd.PermissionsMapForUidAndSnapAndApp(uid, snap, app)
-	permissionEntries := permissionMap[permission]
+	permissionsMap := pd.PermissionsMapForUidAndSnapAndApp(uid, snap, app)
+	permissionEntries := permissionsMap[permission]
 	if permissionEntries == nil {
 		permissionEntries = &permissionDB{
 			Allow:            make(map[string]string),
 			AllowWithDir:     make(map[string]string),
 			AllowWithSubdirs: make(map[string]string),
 		}
-		permissionMap[permission] = permissionEntries
+		permissionsMap[permission] = permissionEntries
 	}
 	return permissionEntries
 }
@@ -517,12 +517,12 @@ func (pd *PromptsDB) insertAndPrune(permissionEntries *permissionDB, decision *S
 	return added, modifiedDeleted, err
 }
 
-func removeDecisionFromPermissionsMap(decision *StoredDecision, permissionMap map[string]*permissionDB) error {
+func removeDecisionFromPermissionsMap(decision *StoredDecision, permissionsMap map[string]*permissionDB) error {
 	path := decision.Path
 	which := decision.AllowType
 	origPermissions := decision.Permissions
 	for _, permission := range origPermissions {
-		db, exists := permissionMap[permission]
+		db, exists := permissionsMap[permission]
 		if !exists {
 			return ErrPermissionNotFound
 		}
@@ -603,8 +603,8 @@ func (pd *PromptsDB) Set(req *notifier.Request, allow bool, extras map[ExtrasKey
 		actuallyAdded, permModifiedDeleted, err := pd.insertAndPrune(permissionEntries, newDecision, permission)
 
 		if err != nil {
-			permissionMap := pd.PermissionsMapForUidAndSnapAndApp(req.SubjectUid, req.Snap, req.App)
-			_ = removeDecisionFromPermissionsMap(newDecision, permissionMap) // ignore second error
+			permissionsMap := pd.PermissionsMapForUidAndSnapAndApp(req.SubjectUid, req.Snap, req.App)
+			_ = removeDecisionFromPermissionsMap(newDecision, permissionsMap) // ignore second error
 			modified, deleted := extractModifiedDeleted(modifiedDeleted)
 			return "", modified, deleted, err
 		}

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -336,9 +336,12 @@ func WhichPermissions(req *notifier.Request, allow bool, extras map[ExtrasKey]st
 // by previous rules in the decision maps given by permissionEntries
 func (pd *PromptsDB) newDecisionImpliedByPreviousDecision(permissionEntries *permissionDB, which AllowType, path string, allow bool) (bool, error) {
 	id, err := pd.findPathInPermissionDB(permissionEntries, path)
-	//alreadyAllowed, err, matchingMap, matchingPath := pd.findPathInPermissionDB(permissionEntries, path)
-	if err != nil && err != ErrNoSavedDecision {
-		return false, err
+	if err != nil {
+		if err == ErrNoSavedDecision {
+			return false, nil
+		} else {
+			return false, err
+		}
 	}
 	alreadyAllowed := pd.decisionIdAllow(id)
 	matchingMap := pd.ById[id].AllowType
@@ -367,7 +370,7 @@ func (pd *PromptsDB) newDecisionImpliedByPreviousDecision(permissionEntries *per
 	//  2. new AllowWithDir, old AllowWithDir, parent match
 	//  3. new AllowWithSubdirs, old _not_ AllowWithSubdirs
 
-	if (err == nil) && (alreadyAllowed == allow) {
+	if alreadyAllowed == allow {
 		// already in db and decision matches
 		if !((which == AllowWithDir && (matchingMap == Allow || (matchingMap == AllowWithDir && matchingPath != path))) || (which == AllowWithSubdirs && matchingMap != AllowWithSubdirs)) {
 			// don't need to do anything

--- a/prompting/storage/storage.go
+++ b/prompting/storage/storage.go
@@ -40,6 +40,20 @@ const (
 	ExtrasDenyExtraPerms   ExtrasKey = "deny-extra-permissions"
 )
 
+type StoredDecision struct {
+	Id           string    `json:"id"`
+	Timestamp    string    `json:"last-modified"`
+	User         uint32    `json:"user"`
+	Snap         string    `json:"snap-name"`
+	App          string    `json:"app-name"`
+	Path         string    `json:"path"`
+	ResourceType string    `json:"resource-type"`
+	Allow        bool      `json:"allow"`
+	Duration     string    `json:"duration"`
+	Permissions  string    `json:"permissions"`
+	AllowType    AllowType `json:"allow-type"`
+}
+
 type permissionDB struct {
 	// must match the AllowType definitions above
 	Allow            map[string]bool `json:"allow"`
@@ -57,12 +71,16 @@ type userDB struct {
 
 // TODO: make this an interface
 type PromptsDB struct {
-	PerUser map[uint32]*userDB `json:"per-user"`
+	PerUser map[uint32]*userDB         `json:"per-user"`
+	ById    map[string]*StoredDecision `json:"by-id"`
 }
 
 // TODO: take a dir as argument to store prompt decisions
 func New() *PromptsDB {
-	pd := &PromptsDB{PerUser: make(map[uint32]*userDB)}
+	pd := &PromptsDB{
+		PerUser: make(map[uint32]*userDB),
+		ById:    make(map[string]*StoredDecision),
+	}
 	// TODO: error handling
 	pd.load()
 	return pd

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -1391,25 +1391,25 @@ func (s *storageSuite) TestFindChildrenInMap(c *C) {
 		matches map[string]string
 	}{
 		{
-			map[string]bool{"/home/test/foo": "a", "/home/test/bar/baz.txt": "b"},
+			map[string]string{"/home/test/foo": "a", "/home/test/bar/baz.txt": "b"},
 			"/home/test",
-			map[string]bool{"/home/test/foo": "a"},
+			map[string]string{"/home/test/foo": "a"},
 		},
 		{
-			map[string]bool{"/home/test/foo": "a", "/home/test/bar/baz.txt": "b"},
+			map[string]string{"/home/test/foo": "a", "/home/test/bar/baz.txt": "b"},
 			"/home/test/bar",
-			map[string]bool{"/home/test/bar/baz.txt": "b"},
+			map[string]string{"/home/test/bar/baz.txt": "b"},
 		},
 		{
-			map[string]bool{"/home/test": "a", "/home/test/foo/file.txt": "b", "/home/test/bar/baz.txt": "c"},
+			map[string]string{"/home/test": "a", "/home/test/foo/file.txt": "b", "/home/test/bar/baz.txt": "c"},
 			"/home/test/foo",
-			map[string]bool{"/home/test/foo/file.txt": "b"},
+			map[string]string{"/home/test/foo/file.txt": "b"},
 		},
 		{
 			// don't match exact path, only children
-			map[string]bool{"/home/test": "a", "/home/test/foo": "b", "/home/test/foo/file.txt": "c", "/home/test/bar": "d"},
+			map[string]string{"/home/test": "a", "/home/test/foo": "b", "/home/test/foo/file.txt": "c", "/home/test/bar": "d"},
 			"/home/test",
-			map[string]bool{"/home/test/foo": "b", "/home/test/bar": "d"},
+			map[string]string{"/home/test/foo": "b", "/home/test/bar": "d"},
 		},
 	}
 	for i, testCase := range cases {
@@ -1425,25 +1425,25 @@ func (s *storageSuite) TestFindDescendantsInMap(c *C) {
 		matches map[string]string
 	}{
 		{
-			map[string]bool{"/home/test/foo": "a", "/home/test/bar/baz.txt": "b"},
+			map[string]string{"/home/test/foo": "a", "/home/test/bar/baz.txt": "b"},
 			"/home/test",
-			map[string]bool{"/home/test/foo": "a", "/home/test/bar/baz.txt": "b"},
+			map[string]string{"/home/test/foo": "a", "/home/test/bar/baz.txt": "b"},
 		},
 		{
-			map[string]bool{"/home/test/foo": "a", "/home/test/bar/baz.txt": "b"},
+			map[string]string{"/home/test/foo": "a", "/home/test/bar/baz.txt": "b"},
 			"/home/test/bar",
-			map[string]bool{"/home/test/bar/baz.txt": "b"},
+			map[string]string{"/home/test/bar/baz.txt": "b"},
 		},
 		{
-			map[string]bool{"/home/test": "a", "/home/test/foo/file.txt": "b", "/home/test/bar/baz.txt": "c"},
+			map[string]string{"/home/test": "a", "/home/test/foo/file.txt": "b", "/home/test/bar/baz.txt": "c"},
 			"/home/test/foo",
-			map[string]bool{"/home/test/foo/file.txt": "b"},
+			map[string]string{"/home/test/foo/file.txt": "b"},
 		},
 		{
 			// don't match exact path, only descendants
-			map[string]bool{"/home/test": "a", "/home/test/foo/file.txt": "b", "/home/test/bar/baz.txt": "c"},
+			map[string]string{"/home/test": "a", "/home/test/foo/file.txt": "b", "/home/test/bar/baz.txt": "c"},
 			"/home/test",
-			map[string]bool{"/home/test/foo/file.txt": "b", "/home/test/bar/baz.txt": "c"},
+			map[string]string{"/home/test/foo/file.txt": "b", "/home/test/bar/baz.txt": "c"},
 		},
 	}
 	for i, testCase := range cases {

--- a/prompting/storage/storage_test.go
+++ b/prompting/storage/storage_test.go
@@ -29,6 +29,8 @@ func (s *storageSuite) TestSimple(c *C) {
 
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 		Path:       "/home/test/foo/",
 		Permission: apparmor.MayReadPermission,
@@ -45,7 +47,7 @@ func (s *storageSuite) TestSimple(c *C) {
 	_, err = st.Set(req, allow, extras)
 	c.Assert(err, IsNil)
 
-	paths := st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "read").AllowWithSubdirs
+	paths := st.MapsForUidAndSnapAndAppAndPermission(req.SubjectUid, req.Snap, req.App, "read").AllowWithSubdirs
 	c.Assert(paths, HasLen, 1)
 
 	allowed, err = st.Get(req)
@@ -70,6 +72,8 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 		Path:       "/home/test/foo/",
 		Permission: apparmor.MayReadPermission,
@@ -91,7 +95,7 @@ func (s *storageSuite) TestSubdirOverrides(c *C) {
 	_, err = st.Set(req, !allow, extras)
 	c.Assert(err, IsNil)
 	// more nested path was added
-	paths := st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "read").AllowWithSubdirs
+	paths := st.MapsForUidAndSnapAndAppAndPermission(req.SubjectUid, req.Snap, req.App, "read").AllowWithSubdirs
 	c.Assert(paths, HasLen, 2)
 
 	// and check more nested path is not allowed
@@ -339,12 +343,14 @@ func (s *storageSuite) TestGetMatches(c *C) {
 
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 		Path:       "placeholder",
 		Permission: apparmor.MayReadPermission,
 	}
 
-	permissionEntries := st.MapsForUidAndLabelAndPermission(req.SubjectUid, req.Label, "read")
+	permissionEntries := st.MapsForUidAndSnapAndAppAndPermission(req.SubjectUid, req.Snap, req.App, "read")
 
 	for i, testCase := range cases {
 		permissionEntries.Allow = cloneAllowMap(testCase.allow)
@@ -434,12 +440,14 @@ func (s *storageSuite) TestGetErrors(c *C) {
 
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 		Path:       "placeholder",
 		Permission: apparmor.MayReadPermission,
 	}
 
-	permissionEntries := st.MapsForUidAndLabelAndPermission(req.SubjectUid, req.Label, "read")
+	permissionEntries := st.MapsForUidAndSnapAndAppAndPermission(req.SubjectUid, req.Snap, req.App, "read")
 
 	for i, testCase := range cases {
 		permissionEntries.Allow = cloneAllowMap(testCase.allow)
@@ -994,12 +1002,14 @@ func (s *storageSuite) TestSetBehaviorWithMatches(c *C) {
 
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 		Path:       "placeholder",
 		Permission: apparmor.MayReadPermission,
 	}
 
-	permissionEntries := st.MapsForUidAndLabelAndPermission(req.SubjectUid, req.Label, "read")
+	permissionEntries := st.MapsForUidAndSnapAndAppAndPermission(req.SubjectUid, req.Snap, req.App, "read")
 
 	for i, testCase := range cases {
 		permissionEntries.Allow = cloneAllowMap(testCase.initialAllow)
@@ -1144,12 +1154,14 @@ func (s *storageSuite) TestSetDecisionPruning(c *C) {
 
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 		Path:       "placeholder",
 		Permission: apparmor.MayReadPermission,
 	}
 
-	permissionEntries := st.MapsForUidAndLabelAndPermission(req.SubjectUid, req.Label, "read")
+	permissionEntries := st.MapsForUidAndSnapAndAppAndPermission(req.SubjectUid, req.Snap, req.App, "read")
 
 	for i, testCase := range cases {
 		permissionEntries.Allow = cloneAllowMap(testCase.initialAllow)
@@ -1236,6 +1248,8 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 		Path:       "/home/test/foo/",
 		Permission: apparmor.MayReadPermission,
@@ -1301,11 +1315,11 @@ func (s *storageSuite) TestPermissionsSimple(c *C) {
 	c.Assert(allowed, Equals, true)
 
 	// check that there are 2 rules for read but the write rule was coalesced
-	paths := st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "read").AllowWithSubdirs
+	paths := st.MapsForUidAndSnapAndAppAndPermission(req.SubjectUid, req.Snap, req.App, "read").AllowWithSubdirs
 	c.Assert(paths, HasLen, 2)
-	paths = st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "write").AllowWithSubdirs
+	paths = st.MapsForUidAndSnapAndAppAndPermission(req.SubjectUid, req.Snap, req.App, "write").AllowWithSubdirs
 	c.Assert(paths, HasLen, 1)
-	paths = st.MapsForUidAndLabelAndPermission(1000, "snap.lxd.lxd", "execute").AllowWithSubdirs
+	paths = st.MapsForUidAndSnapAndAppAndPermission(req.SubjectUid, req.Snap, req.App, "execute").AllowWithSubdirs
 	c.Assert(paths, HasLen, 1)
 }
 
@@ -1314,6 +1328,8 @@ func (s *storageSuite) TestPermissionsComplex(c *C) {
 
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 	}
 	extras := map[storage.ExtrasKey]string{}
@@ -1437,6 +1453,8 @@ func (s *storageSuite) TestPermissionsComplex(c *C) {
 func (s *storageSuite) TestWhichPermissions(c *C) {
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 		Path:       "/home/test/foo",
 		Permission: apparmor.MayReadPermission,
@@ -1464,6 +1482,8 @@ func (s *storageSuite) TestGetDoesNotCorruptPath(c *C) {
 
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 		Path:       "/home/test/foo/",
 		Permission: apparmor.MayReadPermission,
@@ -1484,6 +1504,8 @@ func (s *storageSuite) TestLoadSave(c *C) {
 
 	req := &notifier.Request{
 		Label:      "snap.lxd.lxd",
+		Snap:       "lxd",
+		App:        "lxd",
 		SubjectUid: 1000,
 		Path:       "/home/test/foo",
 		Permission: apparmor.MayReadPermission,


### PR DESCRIPTION
Store decisions by ID as well as in the previous tree organized by UID, label (now snap, app), permission, and path.  This allows constant-time decision lookup, modification, and deletion by ID.  Changes to decisions stored by-ID are propagated to the tree, and vice versa, guaranteeing consistency at all times.

More details discussed here: https://warthogs.atlassian.net/browse/SNAPDENG-7613

Decisions-by-ID are written to disk to allow fast startup times, but there are a few things to consider:

1. If decisions effectively stored in both ways, need to verify consistency between the two at startup (else assume consistency, which is risky)
2. If decisions only stored in tree, rebuilding the by-id map involves scanning the tree and then consolidating the various leaves into their corresponding decisions (many leaves may correspond to a single decision)
3. If decisions only stored by-ID, then the tree must be rebuilt at startup, which is O(n), but this maybe isn't bad, since parsing all the json is O(n) anyway... But it is much harder to read/parse the written data on disk (such as for debugging), which maybe isn't a problem either, since only snapd should _ever_ write to it

So perhaps I favor only storing decisions on-disk by-id.